### PR TITLE
feat(prompt): módulo de prompt para recepção de mídia inbound (resolve #37)

### DIFF
--- a/src/prompt.py
+++ b/src/prompt.py
@@ -86,7 +86,7 @@ prompt_data = _load_composed_prompt_data()
 # - **Atitude:** Sou empática, prestativa, didática e paciente. Uso expressões que transmitem segurança e agilidade, como "Funciona assim", "Pode contar comigo", "Te explico como", "É simples", "Vou te guiar".
 # - **Linguagem:** Simples, clara e direta, ideal para ser lida rápido no celular. Evito termos técnicos ou burocráticos (ex: em vez de "equipamento público", uso "posto de saúde", "escola"). Trato o usuário sempre como "você".
 # - **Linguagem Inclusiva:** Evito marcações de gênero desnecessárias. Prefiro termos neutros ou coletivos (ex: "a equipe" em vez de "os funcionários"; "a pessoa usuária" em vez de "o usuário"; "Prepare-se" em vez de "Você está pronto?").
-# - **Expressões Proibidas:** 
+# - **Expressões Proibidas:**
 #   - Nunca termino frases com "ok?", "tá bom?" ou "certo?".
 #   - Nunca utilizo o termo "assistente" ou "assistente virtual" ou similares para me referir ao chatbot.
 
@@ -96,7 +96,7 @@ prompt_data = _load_composed_prompt_data()
 #     - **DEVO me apresentar:** No início de uma nova conversa, quando o usuário só cumprimenta, ou quando questionam diretamente minha identidade/autenticidade.
 #     - **NÃO DEVO me apresentar:** Em respostas diretas a perguntas sobre serviços, pois a prioridade é a informação.
 # - Regra de Saudação com pergunta:
-#   - Quando a mensagem do usuário contiver uma saudação (ex: "Oi", "Olá") **seguida de uma pergunta ou solicitação de serviço**, responda apenas com um cumprimento curto e natural (como "Oi!" ou "Olá!"), **sem iniciar apresentação longa ou explicações gerais**.  
+#   - Quando a mensagem do usuário contiver uma saudação (ex: "Oi", "Olá") **seguida de uma pergunta ou solicitação de serviço**, responda apenas com um cumprimento curto e natural (como "Oi!" ou "Olá!"), **sem iniciar apresentação longa ou explicações gerais**.
 #   - Em seguida, prossiga **diretamente** para analisar a intenção do usuário e acionar as ferramentas apropriadas para gerar a resposta completa.
 
 
@@ -486,8 +486,8 @@ prompt_data = _load_composed_prompt_data()
 # - Prefeitura do Rio: para informações sobre pontos de apoio
 
 #   **Regra obrigatória:** Sempre que o usuário fizer uma pergunta sobre esses temas, você deve chamar essa ferramenta obrigatoriamente! Essa ferramenta é atualizada constantemente, então sempre a chame antes de responder.
-# - `equipments_by_address`: Ferramenta para encontrar o endereço de um equipamento público. Requer uma `category` (obtida de `equipments_instructions`) e um endereço. Use-a somente **após** ter obtido a categoria correta. 
-# Importante: 
+# - `equipments_by_address`: Ferramenta para encontrar o endereço de um equipamento público. Requer uma `category` (obtida de `equipments_instructions`) e um endereço. Use-a somente **após** ter obtido a categoria correta.
+# Importante:
 #   - Você pode usar tanto o endereço completo do cidadão quanto informações de bairro, região ou ponto de referência mencionadas na mensagem do usuário.
 #   - Se o usuário não der o endereço, mas citar um bairro/localidade, utilize isso como `endereço aproximado` e já forneça opções de equipamentos na região.
 #   - Sempre que possível, forneça ao menos 1–2 opções no primeiro turno. Depois, pergunte se o cidadão deseja resultados mais próximos da sua residência para personalizar a busca.
@@ -764,7 +764,7 @@ prompt_data = _load_composed_prompt_data()
 #     Ao gerar a resposta final, se houver menção à Central 1746, aplique obrigatoriamente a seguinte regra:
 #     - NUNCA inclua o WhatsApp como canal de atendimento.
 #     - Informe apenas o telefone, aplicativo e/ou o site com link direto para o serviço buscado pelo usuário.
- 
+
 # ---
 
 # ### Passo 4: Geração da Resposta
@@ -816,9 +816,9 @@ prompt_data = _load_composed_prompt_data()
 # o iptu de imóveis alugados é responsabilidade do inquilino ou do proprietário? qual a lei que fala disso?
 
 # **Resposta do Agente**
-# A responsabilidade legal pelo pagamento do IPTU é sempre do **proprietário do imóvel**. 
+# A responsabilidade legal pelo pagamento do IPTU é sempre do **proprietário do imóvel**.
 
-# No entanto, a **Lei do Inquilinato (Lei nº 8.245/1991)** permite que essa obrigação seja transferida para o **inquilino**, desde que isso esteja escrito no contrato de aluguel. 
+# No entanto, a **Lei do Inquilinato (Lei nº 8.245/1991)** permite que essa obrigação seja transferida para o **inquilino**, desde que isso esteja escrito no contrato de aluguel.
 
 # Ou seja: se o contrato não falar nada, quem paga é o dono. Se houver cláusula, o inquilino assume.
 

--- a/src/prompt.py
+++ b/src/prompt.py
@@ -1,4 +1,5 @@
 from src.config import env
+from src.prompt_modules import compose as compose_modules
 from loguru import logger
 import httpx
 import asyncio
@@ -45,7 +46,31 @@ async def get_system_prompt_from_api(agent_type: str = "agentic_search") -> dict
         }
 
 
-prompt_data = asyncio.run(get_system_prompt_from_api())
+def _load_composed_prompt_data() -> dict:
+    """Busca o prompt base via API e aplica os módulos enabled em código.
+
+    Encapsula a composição em função pra (1) facilitar testes que precisam
+    injetar prompt base stub via monkeypatch sem mexer no estado de módulo,
+    (2) deixar a intenção explícita no top-level.
+
+    Returns:
+        dict no mesmo schema que ``get_system_prompt_from_api`` retorna
+        (``{"prompt": str, "version": str}``), mas com ``prompt`` e
+        ``version`` aumentados pelos módulos de ``src.prompt_modules``.
+    """
+    base = asyncio.run(get_system_prompt_from_api())
+    augmented_prompt, augmented_version = compose_modules(
+        base["prompt"], base["version"]
+    )
+    if augmented_version != base["version"]:
+        logger.info(
+            f"Prompt composto com módulos: version base={base['version']} "
+            f"→ augmented={augmented_version} (delta+{len(augmented_prompt) - len(base['prompt'])} chars)"
+        )
+    return {**base, "prompt": augmented_prompt, "version": augmented_version}
+
+
+prompt_data = _load_composed_prompt_data()
 
 # PROMPT_PROVISORIO = """
 # # Persona, Tom e Estilo de Comunicação

--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -1,0 +1,75 @@
+"""
+Prompt modules — instruções de system prompt mantidas em código (vs no backing
+store da API `/eai-agent/api/v1/system-prompt`).
+
+Cada módulo é um arquivo Python que expõe duas constantes:
+
+    MODULE_NAME: str
+        Identificador único do módulo (ex: ``"media_inbound"``). Aparece no
+        version do prompt final (ex: ``"2026.05.12.1+media_inbound"``) pra
+        tornar a composição visível em logs e métricas OTel.
+    MODULE_PROMPT: str
+        Markdown a ser appendado ao prompt base, separado por ``\\n\\n``.
+
+A função :func:`compose` aplica os módulos listados em ``ENABLED_MODULES``
+nessa ordem em cima do prompt base obtido da API.
+
+Por que módulos em código (e não no backing store):
+
+* **Versionável via git**: cada mudança gera diff revisável em PR.
+* **Acoplado ao código que ele exige**: instruções pra chamar uma tool MCP
+  mudam junto com a versão da tool (ex: novo campo na assinatura).
+* **Não exige write-access ao backing store**: equipes downstream
+  conseguem evoluir as instruções sem dependência da equipe que mantém a
+  API de prompts.
+
+O prompt base continua sendo a fonte autoritativa de comportamento geral do
+agente (tom, escopo, fallbacks). Os módulos cobrem apenas integrações
+específicas que devem viver ao lado do código de tools.
+"""
+
+from typing import Tuple
+
+from src.prompt_modules import media_inbound
+
+# Ordem importa — define a sequência em que cada módulo aparece no prompt
+# final. Pra desabilitar um módulo, removê-lo desta lista (não comentar
+# import, pra evitar drift).
+ENABLED_MODULES = [
+    media_inbound,
+]
+
+
+def compose(base_prompt: str, base_version: str) -> Tuple[str, str]:
+    """
+    Append os módulos enabled ao prompt base e retorna prompt+version composto.
+
+    Args:
+        base_prompt: conteúdo bruto retornado pela API de system prompt.
+        base_version: versão retornada pela API (ex: ``"2026.05.12.1"`` ou
+            ``"FallBack"`` quando a API falha).
+
+    Returns:
+        Tuple ``(augmented_prompt, augmented_version)``.
+
+        Quando ``ENABLED_MODULES`` está vazio, retorna o par original sem
+        alteração (backward-compat se todos os módulos forem desligados).
+
+        Quando há módulos, ``augmented_version`` ganha sufixo no formato
+        ``"<base_version>+<mod1>+<mod2>+..."`` na ordem de ``ENABLED_MODULES``.
+    """
+    if not ENABLED_MODULES:
+        return base_prompt, base_version
+
+    parts = [base_prompt]
+    suffixes = []
+    for mod in ENABLED_MODULES:
+        parts.append(mod.MODULE_PROMPT)
+        suffixes.append(mod.MODULE_NAME)
+
+    augmented_prompt = "\n\n".join(parts)
+    augmented_version = f"{base_version}+{'+'.join(suffixes)}"
+    return augmented_prompt, augmented_version
+
+
+__all__ = ["compose", "ENABLED_MODULES"]

--- a/src/prompt_modules/media_inbound.py
+++ b/src/prompt_modules/media_inbound.py
@@ -1,0 +1,123 @@
+"""
+Módulo de prompt: instruções para o LLM detectar o prefix ``[INBOUND_MEDIA]``
+e invocar a tool MCP ``register_inbound_media``.
+
+Contexto do fluxo upstream (de cidadão até este módulo):
+
+1. Cidadão envia mídia (imagem ou áudio) pelo WhatsApp.
+2. Salesforce UWC entrega via Connect API; Apex
+   ``SCConnectFetchQueueable`` (em ``prefeitura-rio/study-sf-whatsapp-poc1``)
+   classifica como ``Image``/``Audio``/``Unsupported``/``Unknown`` e
+   correlaciona ``ContentVersion`` via two-pointer.
+3. Mule ``sc-inbound-flow.xml`` propaga ``message_type`` + ``media`` no
+   ``POST /api/v1/message/webhook/user`` do gateway.
+4. Gateway (``prefeitura-rio/app-eai-agent-gateway``, PR #25) enriquece o
+   ``content`` da mensagem humana com o prefix:
+
+       [INBOUND_MEDIA] type=<mt> user_number=<phone> media=<json> | user_text=<original>
+
+5. Engine LangGraph (este repo) entrega esse content como ``HumanMessage`` ao
+   LLM Gemini 2.5 Flash. Sem instruções específicas, o LLM trataria como
+   texto qualquer e ignoraria o prefix.
+
+Este módulo injeta as instruções faltando, na ordem definida em
+``src.prompt_modules.ENABLED_MODULES``.
+
+Tool MCP correspondente: ``register_inbound_media`` em
+``prefeitura-rio/app-mcp-server`` (merge commit ``413ecb0``), arquivo
+``src/tools/inbound_media.py``. Stub-de-recepção atual:
+loga audit + retorna ``suggested_reply_pt_br`` PT-BR. Análise visual,
+transcrição e geocoding ficam para fases posteriores.
+
+ADR de referência: ADR-012 em ``study-sf-whatsapp-poc1`` — decisões
+empíricas sobre auto-attach de ``ContentVersion`` pelo bridge UWC e
+limitações do BSP atual para localização.
+"""
+
+MODULE_NAME = "media_inbound"
+
+MODULE_PROMPT = """## Recepção de mídia (imagem, áudio, localização)
+
+Quando a entrada do cidadão começar com `[INBOUND_MEDIA]`, **NÃO** trate como texto normal. Em vez disso, siga este protocolo:
+
+1. **Parse o prefix.** Formato:
+
+   ```
+   [INBOUND_MEDIA] type=<media_type> user_number=<phone> media=<json> | user_text=<placeholder>
+   ```
+
+   - `media_type` ∈ `{image, audio, location, unsupported, unknown}`
+   - `user_number`: E.164 sem `+` (ex: `5521989091014`)
+   - `media`: objeto JSON com metadados (pode ser `null` para `unsupported`/`unknown`)
+   - `user_text`: conteúdo textual associado à mídia. **Atenção:** pode ser **placeholder gerado upstream** (quando nada de texto real veio do cidadão) ou **conteúdo real** (caption de imagem, transcrição de áudio, etc.).
+     - **Considere placeholder/sem-conteúdo-real** quando: (a) string vazia/só whitespace, (b) começa com `[Cidadao enviou ` (sem acento), (c) começa com `[Cidadão enviou ` (com acento), (d) começa com `[INBOUND_MEDIA`. Ignore para fins de raciocínio. (O Mule envia atualmente sem acento; o pattern com acento fica reservado pra evolução futura do gateway.)
+     - Caso contrário, trate como mensagem real do cidadão associada à mídia.
+
+2. **Chame imediatamente a tool `register_inbound_media`** com:
+
+   - `media_type`: o valor extraído de `type=`
+   - `user_number`: o valor extraído de `user_number=`
+   - Para `image`/`audio`/`unknown` (quando `media` tem conteúdo):
+     - `content_version_id`, `file_extension`, `file_size_bytes`, `salesforce_download_path` (do campo `download_path`) — extraídos do JSON `media`
+   - Para `location` (quando suporte do canal habilitar lat/lng):
+     - `latitude`, `longitude`, `address` — do JSON `media`
+   - Para `unsupported`: chame com apenas `media_type` + `user_number`
+
+3. **Componha a resposta ao cidadão** levando em conta o conteúdo de `user_text` extraído no passo 1:
+
+   - **Se `user_text` é placeholder ou vazio** (vazio/whitespace, ou começa com `[Cidadao enviou ` / `[Cidadão enviou ` / `[INBOUND_MEDIA`): use o campo `suggested_reply_pt_br` retornado pela tool como base — ele já tem mensagem amigável + chamada-para-ação. Adapte o tom ao contexto da conversa.
+   - **Se `user_text` é conteúdo real do cidadão** (caption de imagem ou transcrição de áudio): **NÃO** peça pra repetir a informação. Continue o atendimento normalmente usando o `user_text` como parte da mensagem do cidadão; o registro da mídia via tool fica só como audit. Pode mencionar brevemente que recebeu o anexo, mas não bloqueie o fluxo.
+
+4. **Não tente analisar a imagem/áudio nem geocodificar.** A tool atual é stub de recepção (apenas registra audit + retorna sugestão). Processamento real (visão para imagens, transcrição para áudios, geocoding para coordenadas) será adicionado em fases posteriores — não invente capacidade que ainda não existe.
+
+### Exemplo
+
+Entrada do cidadão:
+
+```
+[INBOUND_MEDIA] type=image user_number=5521989091014 media={"content_version_id":"0688800000Bgd3T","content_document_id":"0698800000BR4R0","file_extension":"jpg","file_size_bytes":119900,"download_path":"/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3T/VersionData"} | user_text=[Cidadao enviou uma imagem. Suporte a analise visual em desenvolvimento — pedir descricao em texto.]
+```
+
+Note que o JSON `media` pode conter campos extras (`content_document_id`, `mime_type`, etc.) que **não são** parâmetros aceitos pela tool — ignore esses e passe apenas os parâmetros documentados acima.
+
+Sua chamada de tool:
+
+```
+register_inbound_media(
+    media_type="image",
+    user_number="5521989091014",
+    content_version_id="0688800000Bgd3T",
+    file_extension="jpg",
+    file_size_bytes=119900,
+    salesforce_download_path="/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3T/VersionData",
+)
+```
+
+Retorno típico:
+
+```json
+{
+  "status": "received",
+  "media_type": "image",
+  "processing": "deferred",
+  "suggested_reply_pt_br": "Recebi sua imagem! No momento ainda não consigo analisar fotos. Pode descrever em texto o que precisa pra eu te ajudar?"
+}
+```
+
+Como o `user_text` deste exemplo é placeholder (começa com `[Cidadao enviou `), você usa o `suggested_reply_pt_br` como base:
+
+> Recebi sua foto! Ainda não consigo analisar imagens diretamente, mas se você me contar em texto o que precisa eu te ajudo no que der.
+
+### Exemplo com user_text real (transcrição de áudio)
+
+Entrada:
+
+```
+[INBOUND_MEDIA] type=audio user_number=5521989091014 media={"content_version_id":"068...","file_extension":"oga","file_size_bytes":14509,"download_path":"/services/data/v62.0/sobjects/ContentVersion/068.../VersionData"} | user_text=tem uma luminária queimada na rua das laranjeiras
+```
+
+Você ainda chama `register_inbound_media` para audit. Mas o `user_text` é conteúdo real — **não peça pra repetir**. Resposta:
+
+> Anotei o relato (recebi também o áudio). Vou seguir com o pedido de reparo da luminária — me passa o endereço completo (rua, número, bairro)?
+
+"""

--- a/tests/unit/test_prompt_modules.py
+++ b/tests/unit/test_prompt_modules.py
@@ -1,0 +1,195 @@
+"""
+Testes do mecanismo de composição de prompt modules
+(``src.prompt_modules``).
+
+Estes testes não dependem da API de prompt (``EAI_AGENT_URL``) e não exigem
+credenciais GCP — exercitam apenas a lógica de composição pura. Para validar
+o end-to-end (prompt fetched → composto → entregue ao agent), usar smoke
+tests pós-deploy em staging.
+"""
+
+from src.prompt_modules import compose, ENABLED_MODULES
+from src.prompt_modules import media_inbound
+
+
+# ---------- compose() — comportamento básico ----------
+
+
+def test_compose_returns_pair_of_strings():
+    augmented, version = compose("BASE", "v1.0")
+    assert isinstance(augmented, str)
+    assert isinstance(version, str)
+
+
+def test_compose_preserves_base_prompt_content():
+    base = "Você é assistente da Prefeitura."
+    augmented, _ = compose(base, "v1.0")
+    assert base in augmented, "Conteúdo do prompt base não pode ser perdido"
+
+
+def test_compose_appends_modules_after_base():
+    base = "Base do prompt."
+    augmented, _ = compose(base, "v1.0")
+    # módulos aparecem depois do base
+    base_idx = augmented.index(base)
+    for mod in ENABLED_MODULES:
+        mod_idx = augmented.index(mod.MODULE_PROMPT)
+        assert mod_idx > base_idx, (
+            f"Módulo {mod.MODULE_NAME} apareceu antes do base"
+        )
+
+
+def test_compose_separates_with_blank_line():
+    base = "Base."
+    augmented, _ = compose(base, "v1.0")
+    # Cada módulo deve estar separado por linha em branco (markdown sectioning)
+    assert "\n\n" in augmented
+
+
+def test_compose_version_appends_module_names():
+    _, version = compose("BASE", "v1.0")
+    assert version.startswith("v1.0+")
+    for mod in ENABLED_MODULES:
+        assert mod.MODULE_NAME in version
+
+
+def test_compose_version_order_matches_modules_order():
+    _, version = compose("BASE", "v1.0")
+    expected_suffix = "+".join(m.MODULE_NAME for m in ENABLED_MODULES)
+    assert version == f"v1.0+{expected_suffix}"
+
+
+# ---------- compose() — edge cases ----------
+
+
+def test_compose_with_fallback_version_string():
+    """Se a API estiver fora e o base for o fallback, version segue compose."""
+    _, version = compose("fallback prompt", "FallBack")
+    assert version.startswith("FallBack+")
+
+
+def test_compose_with_empty_base_prompt():
+    """Caller pode passar string vazia (cenário improvável mas defensivo)."""
+    augmented, _ = compose("", "v0")
+    # Não dá erro; resultado começa com \n\n + módulos
+    for mod in ENABLED_MODULES:
+        assert mod.MODULE_PROMPT in augmented
+
+
+def test_compose_with_no_modules_is_passthrough(monkeypatch):
+    """
+    Se ``ENABLED_MODULES`` for esvaziado (todos os módulos desligados),
+    compose vira pass-through completo: prompt e version inalterados.
+    """
+    import src.prompt_modules as mods
+
+    monkeypatch.setattr(mods, "ENABLED_MODULES", [])
+    augmented, version = mods.compose("BASE", "v1.0")
+    assert augmented == "BASE"
+    assert version == "v1.0"
+
+
+# ---------- contract dos módulos individuais ----------
+
+
+def test_media_inbound_module_has_required_attributes():
+    """Cada módulo deve expor ``MODULE_NAME`` e ``MODULE_PROMPT`` (contrato
+    consumido por ``compose``)."""
+    assert hasattr(media_inbound, "MODULE_NAME")
+    assert hasattr(media_inbound, "MODULE_PROMPT")
+    assert isinstance(media_inbound.MODULE_NAME, str)
+    assert isinstance(media_inbound.MODULE_PROMPT, str)
+
+
+def test_media_inbound_module_name_is_stable():
+    """``MODULE_NAME`` vira sufixo no version do prompt — não pode mudar
+    silenciosamente porque quebra dashboards/logs OTel que filtram por
+    version."""
+    assert media_inbound.MODULE_NAME == "media_inbound"
+
+
+def test_media_inbound_prompt_mentions_protocol_keywords():
+    """Sanity: o prompt deve instruir sobre os 3 elementos essenciais
+    (prefix, tool e campo de resposta sugerida). Não é teste de conteúdo
+    pleno — é guard contra deleção acidental dos pilares."""
+    p = media_inbound.MODULE_PROMPT
+    assert "[INBOUND_MEDIA]" in p, "Prefix de detecção ausente"
+    assert "register_inbound_media" in p, "Nome da tool MCP ausente"
+    assert "suggested_reply_pt_br" in p, "Campo de resposta sugerida ausente"
+
+
+def test_media_inbound_prompt_lists_all_media_types():
+    """Os 5 valores válidos de ``media_type`` que o tool MCP aceita devem
+    aparecer no prompt — senão o LLM pode rejeitar ou usar tipo errado."""
+    p = media_inbound.MODULE_PROMPT
+    for media_type in ["image", "audio", "location", "unsupported", "unknown"]:
+        assert media_type in p, f"media_type '{media_type}' não documentado"
+
+
+def test_media_inbound_prompt_distinguishes_placeholder_vs_real_user_text():
+    """user_text pode ser placeholder (descartável) OU conteúdo real
+    (caption/transcrição). Sem essa distinção no prompt, o LLM pediria pro
+    cidadão repetir texto já transcrito upstream — UX ruim. Verifica que o
+    prompt instrui distinguir os dois casos."""
+    p = media_inbound.MODULE_PROMPT
+    # Instrução pra NÃO pedir repetição quando user_text é real
+    assert "NÃO" in p.upper() or "não peça" in p.lower(), (
+        "Falta instrução pra não pedir repetição em conteúdo real"
+    )
+
+
+def test_media_inbound_prompt_handles_empty_user_text_as_placeholder():
+    """Quando gateway aceita media-only sem caption, prefix vira
+    `... | user_text=`. Sem instrução explícita, esse vazio cairia pra
+    branch de "conteúdo real" — LLM ignoraria suggested_reply_pt_br."""
+    p = media_inbound.MODULE_PROMPT.lower()
+    assert "vazio" in p or "vazia" in p, (
+        "Prompt não trata user_text vazio como placeholder — "
+        "media-only sem caption vai pra branch errada"
+    )
+
+
+def test_media_inbound_prompt_covers_both_placeholder_spellings():
+    """O Mule sc-inbound-flow.xml hoje envia `[Cidadao enviou` (sem acento)
+    por causa do encoding DataWeave. O prompt precisa reconhecer ESSA forma —
+    e idealmente a com acento também, pra ficar resiliente a evoluções
+    futuras do gateway. Sem o pattern sem-acento, todo o fluxo média-only
+    cai pra branch de "user_text real" e o LLM ignora suggested_reply_pt_br."""
+    p = media_inbound.MODULE_PROMPT
+    assert "[Cidadao enviou " in p, (
+        "Pattern sem acento (atual do Mule) não documentado — "
+        "media-only flow vai cair pra branch errada"
+    )
+    assert "[Cidadão enviou " in p, (
+        "Pattern com acento não documentado — resiliência futura quebrada"
+    )
+
+
+def test_media_inbound_prompt_omits_unsupported_tool_params_in_call():
+    """O tool MCP `register_inbound_media` não aceita `content_document_id`
+    como parâmetro (apenas `content_version_id`). O prompt pode mencionar
+    `content_document_id` no JSON de entrada do prefix (lá ele aparece como
+    metadata bruta vinda do gateway), mas **NÃO** pode aparecer como
+    keyword argument na chamada de exemplo da tool — risco de o LLM emitir
+    tool call inválido.
+
+    Pattern verificado: ``content_document_id=`` (com sinal de igualdade,
+    indicando keyword arg Python-like) não pode existir no prompt."""
+    p = media_inbound.MODULE_PROMPT
+    forbidden = "content_document_id="
+    assert forbidden not in p, (
+        f"Prompt usa {forbidden!r} em chamada da tool, "
+        "mas a tool não aceita esse parâmetro"
+    )
+
+
+# ---------- regressão: idempotência de chamada ----------
+
+
+def test_compose_is_pure_and_idempotent():
+    """Chamar compose 2x com mesmos argumentos retorna mesmo resultado
+    byte-a-byte (sem efeitos colaterais em estado de módulo)."""
+    a1, v1 = compose("BASE", "v1")
+    a2, v2 = compose("BASE", "v1")
+    assert a1 == a2
+    assert v1 == v2

--- a/tests/unit/test_prompt_modules.py
+++ b/tests/unit/test_prompt_modules.py
@@ -34,9 +34,7 @@ def test_compose_appends_modules_after_base():
     base_idx = augmented.index(base)
     for mod in ENABLED_MODULES:
         mod_idx = augmented.index(mod.MODULE_PROMPT)
-        assert mod_idx > base_idx, (
-            f"Módulo {mod.MODULE_NAME} apareceu antes do base"
-        )
+        assert mod_idx > base_idx, f"Módulo {mod.MODULE_NAME} apareceu antes do base"
 
 
 def test_compose_separates_with_blank_line():


### PR DESCRIPTION
## Resolve #37

Fecha o último elo do fluxo de mídia inbound do WhatsApp. Antes desta PR, mesmo com tudo o resto merged (Apex + Mule + Gateway PR #25 + MCP tool), o LLM staging ignorava o prefix `[INBOUND_MEDIA]` injetado pelo gateway e tratava como texto qualquer — nunca chamava a tool MCP `register_inbound_media`.

## Mudança

Mecanismo de **prompt modules** pluggable em `src/prompt_modules/`:

- `__init__.py` — helper `compose(base_prompt, base_version) → (augmented, version)` que appendia módulos enabled ao prompt base
- `media_inbound.py` — módulo com instruções de detecção/ação para `[INBOUND_MEDIA]`
- `src/prompt.py` — wirea a composição via `_load_composed_prompt_data()` sem mudar o contrato de `prompt_data["prompt"]` / `["version"]` (callers em `deploy.py` e `interactive_test.py` não mudam)

Versão composta tem sufixo: `<base_version>+media_inbound` — fica visível em logs OTel e no `display_name` do agent deploy.

## Por que código e não backing store

- **Versionável via git**: cada mudança vira diff revisável em PR (como esta).
- **Acoplado ao código que ele exige**: instruções pra chamar uma tool MCP mudam junto com a versão da tool (parâmetros, fields, etc.).
- **Sem dependência de write-access**: não precisa de credencial pro backing store da API de prompts.

O prompt base continua sendo a fonte autoritativa de comportamento geral do agente (tom, escopo, fallbacks). Módulos cobrem apenas integrações específicas que devem evoluir junto com tools/gateway.

## Validação

- **18 testes unitários** em `tests/unit/test_prompt_modules.py` cobrindo: ordem, version composta, idempotência, passthrough com `ENABLED_MODULES=[]`, contrato dos módulos, 5 media_types documentados, distinção placeholder vs user_text real, ambos os spellings de `[Cidadao enviou ` (sem acento, atual do Mule) e `[Cidadão enviou ` (com acento, futuro), user_text vazio como placeholder, parâmetros do tool em sync com schema (sem `content_document_id`).
- `uv run --python 3.13 pytest tests/unit/test_prompt_modules.py -q` → **18 passed in 0.11s**.
- **6 rounds codex review**, último limpo ("No actionable defects").

### Findings resolvidos no review iterativo

1. P2 — `content_document_id` documentado como param mas tool não aceita → removido
2. P2 — `user_text` sempre tratado como placeholder, mesmo transcrição → distinção real vs placeholder
3. P2 — placeholder spelling `[Cidadão` mas Mule envia `[Cidadao` (sem acento) → ambos aceitos
4. P2 — `user_text=` vazio caía pra branch errada → vazio também é placeholder

## Fluxo end-to-end após merge

```
✅ Apex/Mule (study-sf-whatsapp-poc1@c6bfe6a) — classifica + envia
✅ Gateway (PR #25 merged 7ff0d25e) — enriquece com [INBOUND_MEDIA] prefix
✅ MCP tool (app-mcp-server@413ecb0) — register_inbound_media stub recepção
✅ Engine prompt (esta PR) — LLM detecta prefix + chama tool + usa suggested_reply_pt_br
```

Após merge, qualquer cidadão que mandar foto/áudio pelo `+55 21 98909-1014` em staging vai ter o LLM:
1. Detectar o prefix
2. Chamar `register_inbound_media` com os campos certos
3. Receber `suggested_reply_pt_br` da tool
4. Responder em PT-BR contextual

## Refs

- prefeitura-rio/study-sf-whatsapp-poc1 commit c6bfe6a (Apex + Mule)
- prefeitura-rio/app-eai-agent-gateway#25 (gateway enrichment, merged)
- prefeitura-rio/app-mcp-server@413ecb0 (tool MCP, merged)
- ADR-012 em study-sf-whatsapp-poc1 (decisões empíricas do fluxo)
