### PR TITLE
feat(prompt): módulo vision_inbound — opt-in para analyze_inbound_image

### DIFF
--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -30,13 +30,19 @@ específicas que devem viver ao lado do código de tools.
 
 from typing import Tuple
 
-from src.prompt_modules import media_inbound
+from src.prompt_modules import media_inbound, vision_inbound
 
 # Ordem importa — define a sequência em que cada módulo aparece no prompt
 # final. Pra desabilitar um módulo, removê-lo desta lista (não comentar
 # import, pra evitar drift).
+#
+# vision_inbound depende semanticamente de media_inbound (refere o protocolo
+# do ``[INBOUND_MEDIA]`` definido lá), portanto vem DEPOIS. O suggested_reply
+# do analyze_inbound_image substitui o do register_inbound_media — a ordem
+# das instruções no prompt importa pro LLM resolver o "qual usar".
 ENABLED_MODULES = [
     media_inbound,
+    vision_inbound,
 ]
 
 

--- a/src/prompt_modules/vision_inbound.py
+++ b/src/prompt_modules/vision_inbound.py
@@ -1,0 +1,154 @@
+"""
+Módulo de prompt: instruções para o LLM chamar a tool MCP
+``analyze_inbound_image`` (Gemini Vision) depois de ``register_inbound_media``
+quando o cidadão envia uma imagem via WhatsApp.
+
+Contexto:
+
+* :mod:`src.prompt_modules.media_inbound` já instrui o LLM a chamar
+  ``register_inbound_media`` (stub de recepção/audit) quando vê o prefix
+  ``[INBOUND_MEDIA]``. Esse stub registra mas não analisa.
+* A tool MCP ``analyze_inbound_image`` (em
+  ``prefeitura-rio/app-mcp-server`` commit ``71202f62``, arquivo
+  ``src/tools/inbound_media_vision.py``) faz análise visual real via
+  Gemini Vision e classifica em workflows (``reparo_luminaria``,
+  ``poda_de_arvore``, ``nenhum``). É **opt-in** no MCP via flag
+  ``ENABLE_VISION_ADDENDUM=true`` — sem o flag a tool não é registrada e
+  o LLM nem a vê (instruções abaixo viram no-op).
+
+Quando a tool está registrada, o LLM deve chamar ela DEPOIS do
+``register_inbound_media`` mas ANTES de responder ao cidadão. O
+``suggested_reply_pt_br`` da análise visual substitui o do registro stub.
+
+**Limitação conhecida (fase atual):** ``analyze_inbound_image`` requer
+``image_bytes_base64`` ou ``local_image_path``. Em produção via Engine,
+nenhum dos dois é fornecido automaticamente pelo Gateway hoje (só
+``salesforce_download_path``). Até o Engine team implementar pré-fetch
+de bytes do Salesforce e injeção no contexto da mensagem, a tool pode
+retornar erro/análise vazia em prod. Mantemos a instrução pro LLM
+porque (a) staging com upload manual de bytes funciona, (b) quando o
+pre-fetch chegar (fase 2), nenhum redeploy de prompt será necessário.
+
+Refs:
+    - ``prefeitura-rio/app-mcp-server`` merge commit ``71202f62`` (PR #56)
+    - ``prefeitura-rio/study-sf-whatsapp-poc1`` ADR-012
+    - ``src/prompt_modules/media_inbound.py`` (módulo predecessor)
+"""
+
+MODULE_NAME = "vision_inbound"
+
+MODULE_PROMPT = """## Análise visual de imagem inbound (extensão de mídia)
+
+Quando o passo anterior identificou ``media_type=image`` (via
+``register_inbound_media`` do módulo "Recepção de mídia"), você PODE
+tentar análise visual via ``analyze_inbound_image``. Decisão sobre
+chamá-la ou não segue a árvore abaixo:
+
+### Decisão: chamar ``analyze_inbound_image`` ou pular?
+
+**Chamar somente se TODAS as 2 condições forem verdadeiras:**
+
+(a) A tool ``analyze_inbound_image`` está disponível no seu toolset
+    (opt-in via ``ENABLE_VISION_ADDENDUM=true`` no MCP — se a tool não
+    estiver listada, ela não está disponível).
+
+(b) Você tem acesso aos bytes da imagem em uma destas formas:
+    - ``image_bytes_base64`` no contexto da mensagem (modo produção
+      fase 2, quando Engine pré-baixar do Salesforce)
+    - ``local_image_path`` no JSON do prefix ``[INBOUND_MEDIA]`` (modo
+      teste local com upload manual)
+
+**Se qualquer uma das 2 condições falhar, NÃO chame a tool.** Volte
+inteiramente ao protocolo do módulo "Recepção de mídia" — ele já trata
+corretamente a distinção entre placeholder (use ``suggested_reply_pt_br``
+do registro) vs caption real (use o ``user_text`` como mensagem do
+cidadão, sem pedir pra repetir). Não há regressão nesse caminho.
+
+> ``salesforce_download_path`` sozinho NÃO basta — ``analyze_inbound_image``
+> não baixa do Salesforce. Chamar a tool sem ``image_bytes_base64`` nem
+> ``local_image_path`` causa erro/análise vazia; melhor pular.
+
+### Quando AS DUAS condições passam, executar análise
+
+1. **Chamar ``analyze_inbound_image``** logo após o ``register_inbound_media``:
+
+   - ``user_number``: mesmo valor extraído do prefix ``[INBOUND_MEDIA]``
+   - ``file_extension``: do campo ``media.file_extension``
+   - ``message_id``: do prefix se disponível (audit cross-ref)
+   - ``content_version_id``: do campo ``media.content_version_id``
+   - ``image_bytes_base64`` OU ``local_image_path`` (pelo menos um)
+
+2. **Usar a resposta da análise.** O retorno contém ``analysis`` com:
+
+   - ``descricao``: o que a foto mostra
+   - ``problema_detectado``: bool
+   - ``categoria``: ``luminaria_publica``/``poda_arvore``/``buraco_via``/etc.
+   - ``workflow_sugerido``: ``reparo_luminaria``/``poda_de_arvore``/``nenhum``
+   - ``confianca``: ``alta``/``media``/``baixa``
+
+   E ``suggested_reply_pt_br`` baseado na análise. Use **esse**
+   ``suggested_reply_pt_br`` (da análise visual) como base da resposta
+   ao cidadão — NÃO o do ``register_inbound_media``, que é genérico.
+
+   Se ``user_text`` veio com caption real do cidadão, **combine**: cite
+   tanto o que viu na imagem quanto o que o cidadão disse, sem pedir
+   pra ele repetir o que já escreveu.
+
+3. **Iniciar workflow se aplicável.** Se
+   ``analysis.workflow_sugerido`` for ``reparo_luminaria`` ou
+   ``poda_de_arvore`` E a ``confianca`` for ``alta`` ou ``media``:
+
+   - Confirme com o cidadão a categoria detectada antes de iniciar o
+     workflow ("Vi uma luminária com o globo quebrado — confirma que
+     é isso?").
+   - Após confirmação, inicie via ``multi_step_service`` com o
+     ``service_name`` correspondente.
+
+4. **Fallback se análise falha ou é inconclusiva.** Se a tool retornar
+   erro, ``problema_detectado=false`` com ``categoria=nao_aplica``, ou
+   ``confianca=baixa``, **volte ao protocolo do módulo "Recepção de
+   mídia"** (mesmo princípio do "tool indisponível" acima — não invente
+   diagnóstico não suportado pela análise; se há ``user_text`` real,
+   continue a partir dele).
+
+### Exemplo de fluxo (imagem de luminária quebrada)
+
+Após ``register_inbound_media`` ter sido chamado para a imagem,
+você chama:
+
+```
+analyze_inbound_image(
+    user_number="5521989091014",
+    file_extension="jpg",
+    content_version_id="0688800000Bgd3T",
+    image_bytes_base64="<bytes do contexto>",
+)
+```
+
+Retorno típico:
+
+```json
+{
+  "status": "ok",
+  "analysis": {
+    "descricao": "Poste de luminária pública com lâmpada quebrada",
+    "problema_detectado": true,
+    "categoria": "luminaria_publica",
+    "detalhes": "Vidro do globo da luminária quebrado, lâmpada visível",
+    "workflow_sugerido": "reparo_luminaria",
+    "confianca": "alta"
+  },
+  "suggested_reply_pt_br": "Vi na foto que a luminária pública está com o globo quebrado. Posso abrir o pedido de reparo pra você? Me confirma o endereço (rua, número, bairro) e a gente segue."
+}
+```
+
+Sua resposta ao cidadão (adaptando o ``suggested_reply_pt_br``):
+
+> Olhei sua foto — luminária com globo quebrado, anotado.
+> Pra abrir o pedido de reparo preciso do endereço (rua, número, bairro).
+> Pode me passar?
+
+Depois da confirmação do endereço, chame
+``multi_step_service(service_name="reparo_luminaria", user_id=user_number, payload=...)``
+pra iniciar o workflow.
+"""

--- a/tests/unit/test_prompt_modules.py
+++ b/tests/unit/test_prompt_modules.py
@@ -9,7 +9,7 @@ tests pós-deploy em staging.
 """
 
 from src.prompt_modules import compose, ENABLED_MODULES
-from src.prompt_modules import media_inbound
+from src.prompt_modules import media_inbound, vision_inbound
 
 
 # ---------- compose() — comportamento básico ----------
@@ -179,6 +179,72 @@ def test_media_inbound_prompt_omits_unsupported_tool_params_in_call():
         f"Prompt usa {forbidden!r} em chamada da tool, "
         "mas a tool não aceita esse parâmetro"
     )
+
+
+# ---------- módulo vision_inbound ----------
+
+
+def test_vision_inbound_module_has_required_attributes():
+    """vision_inbound deve seguir o mesmo contrato dos outros módulos."""
+    assert hasattr(vision_inbound, "MODULE_NAME")
+    assert hasattr(vision_inbound, "MODULE_PROMPT")
+    assert isinstance(vision_inbound.MODULE_NAME, str)
+    assert isinstance(vision_inbound.MODULE_PROMPT, str)
+
+
+def test_vision_inbound_module_name_is_stable():
+    """MODULE_NAME do vision_inbound vira sufixo no version (e em logs OTel)."""
+    assert vision_inbound.MODULE_NAME == "vision_inbound"
+
+
+def test_vision_inbound_prompt_mentions_analyze_tool():
+    """Sanity: prompt deve nomear a tool MCP `analyze_inbound_image` que
+    deve ser chamada — sem isso, o LLM não sabe o nome exato e pode
+    chutar ou nem tentar."""
+    p = vision_inbound.MODULE_PROMPT
+    assert "analyze_inbound_image" in p, "Nome da tool MCP de visão ausente"
+    assert "register_inbound_media" in p, "Referência à tool antecedente ausente"
+
+
+def test_vision_inbound_prompt_handles_opt_in_fallback():
+    """A tool é opt-in (ENABLE_VISION_ADDENDUM=true no MCP). Quando não
+    registrada, LLM nem vê o nome. Mas o prompt precisa instruir o
+    fallback explícito pra esse caso pra evitar travamento."""
+    p = vision_inbound.MODULE_PROMPT.lower()
+    assert "indisponível" in p or "indisponivel" in p or "disponível" in p, (
+        "Falta instrução sobre comportamento quando tool não está registrada"
+    )
+
+
+def test_vision_inbound_prompt_warns_about_missing_bytes():
+    """analyze_inbound_image NÃO baixa do Salesforce — precisa de
+    image_bytes_base64 OU local_image_path. Sem nenhum dos dois, ela
+    falha. Prompt deve avisar pra LLM não chamar sem bytes."""
+    p = vision_inbound.MODULE_PROMPT
+    assert "salesforce_download_path" in p, "Path do SF não documentado"
+    assert "image_bytes_base64" in p, "Bytes em base64 não documentados"
+    assert "local_image_path" in p, "Path local não documentado"
+
+
+def test_vision_module_appears_after_media_module_in_enabled():
+    """vision_inbound depende semanticamente de media_inbound — a ordem
+    das instruções no prompt importa pro LLM resolver "qual reply usar"
+    (vision suggested_reply substitui o do register stub)."""
+    names = [m.MODULE_NAME for m in ENABLED_MODULES]
+    assert "media_inbound" in names
+    assert "vision_inbound" in names
+    assert names.index("media_inbound") < names.index("vision_inbound"), (
+        "vision_inbound deve vir DEPOIS de media_inbound em ENABLED_MODULES"
+    )
+
+
+def test_vision_inbound_workflow_suggestions_in_prompt():
+    """Os workflows que a análise visual pode sugerir devem estar
+    documentados no prompt pra o LLM saber qual chamar via
+    `multi_step_service`."""
+    p = vision_inbound.MODULE_PROMPT
+    for workflow in ["reparo_luminaria", "poda_de_arvore"]:
+        assert workflow in p, f"workflow '{workflow}' não documentado"
 
 
 # ---------- regressão: idempotência de chamada ----------


### PR DESCRIPTION
## Resumo

Segundo módulo de prompt no Engine — ensina LLM a chamar a tool MCP `analyze_inbound_image` (Gemini Vision real) quando disponível + bytes acessíveis. Predecessor: módulo `media_inbound` (PR #38).

Closes loop iniciado em #38 — agora que a tool real de visão existe no MCP (prefeitura-rio/app-mcp-server@71202f62, PR #56 merged), Engine instrui LLM a usá-la sem regredir o fluxo de mídia stub quando a tool não está ativa.

## Decisões de design

**Opt-in em 2 niveis:**

| Estado | Comportamento do LLM |
|---|---|
| Tool ausente (MCP sem `ENABLE_VISION_ADDENDUM=true`) | Fallback ao módulo `media_inbound` — fluxo atual mantido |
| Tool presente mas sem bytes (`image_bytes_base64`/`local_image_path` ausentes) | Não chama; fallback ao `media_inbound` |
| Tool presente + bytes | Chama, usa `analysis.suggested_reply_pt_br`; pode iniciar workflow via `multi_step_service` |

**Por que pular quando bytes faltam:** `analyze_inbound_image` não baixa do Salesforce (`salesforce_download_path` sozinho não basta). Fase 2 do Engine team incluirá pre-fetch upstream que injeta `image_bytes_base64` no contexto. Até lá, fallback é mais seguro que chamada que retorna análise vazia.

**Ordem no `ENABLED_MODULES`:** `media_inbound` → `vision_inbound`. Importa pq `vision_inbound` referencia o protocolo de `media_inbound` ("volte ao protocolo do módulo anterior em caso de fallback").

## Validação

- **25 testes unitários** (anteriores 18 + 7 novos), `pytest tests/unit/test_prompt_modules.py` 100% pass
- `ruff format --check` ✅ + `ruff check` ✅
- **2 rounds codex review**, último limpo. Round #1 achou 2 issues reais (fallback regressivo pra captions reais + step 4 alcançável com tool desabilitada) — ambos corrigidos.

## Cobertura de testes novos

- contrato `MODULE_NAME`/`MODULE_PROMPT`
- ordem `media_inbound` antes de `vision_inbound`
- prompt nomeia ambas as tools (`register_inbound_media` + `analyze_inbound_image`)
- documenta fallback explícito quando tool indisponível
- avisa sobre `salesforce_download_path` não bastar
- workflows sugeridos (`reparo_luminaria`, `poda_de_arvore`) documentados

## Deploy pós-merge

Pra ativar:
1. Merge desta PR → branch `staging`
2. `python -m src.deploy` (cria nova versão `vXXX+media_inbound+vision_inbound` do Reasoning Engine)
3. Infisical staging: `REASONING_ENGINE_ID = <novo ID>`
4. MCP precisa de `ENABLE_VISION_ADDENDUM=true` no Infisical (caso queira a tool ativa)
5. Caso fase 2 (pre-fetch de bytes) ainda não esteja pronta, vision permanece dormante — sem regressão no fluxo atual.
