### PR TITLE
feat(prompt): orienta LLM a pedir endereço e geocodar via validate_address quando media_type=unsupported

### DIFF
--- a/src/prompt_modules/media_inbound.py
+++ b/src/prompt_modules/media_inbound.py
@@ -68,7 +68,37 @@ Quando a entrada do cidadão começar com `[INBOUND_MEDIA]`, **NÃO** trate como
    - **Se `user_text` é placeholder ou vazio** (vazio/whitespace, ou começa com `[Cidadao enviou ` / `[Cidadão enviou ` / `[INBOUND_MEDIA`): use o campo `suggested_reply_pt_br` retornado pela tool como base — ele já tem mensagem amigável + chamada-para-ação. Adapte o tom ao contexto da conversa.
    - **Se `user_text` é conteúdo real do cidadão** (caption de imagem ou transcrição de áudio): **NÃO** peça pra repetir a informação. Continue o atendimento normalmente usando o `user_text` como parte da mensagem do cidadão; o registro da mídia via tool fica só como audit. Pode mencionar brevemente que recebeu o anexo, mas não bloqueie o fluxo.
 
-4. **Não tente analisar a imagem/áudio nem geocodificar.** A tool atual é stub de recepção (apenas registra audit + retorna sugestão). Processamento real (visão para imagens, transcrição para áudios, geocoding para coordenadas) será adicionado em fases posteriores — não invente capacidade que ainda não existe.
+4. **Não tente analisar a imagem/áudio.** A tool `register_inbound_media` é stub de recepção (apenas registra audit + retorna sugestão). Processamento de imagem usa a tool separada `analyze_inbound_image` (quando disponível, conforme módulo `vision_inbound`). Transcrição de áudio será adicionada em fases posteriores — não invente capacidade que ainda não existe.
+
+### Caso especial: `media_type=unsupported` (geocoding via texto)
+
+Quando `media_type=unsupported`, o canal BSP-managed bloqueou o conteúdo que o cidadão tentou enviar. **A causa predominante é tentativa de compartilhar localização** (pin de mapa), mas pode também ser vídeo, sticker, documento, etc. Bruno confirmou em 2026-05-12 que destravar o canal BSP-side não é viável no curto prazo (ver ADR-013 em `study-sf-whatsapp-poc1`).
+
+Fluxo correto:
+
+1. Chame `register_inbound_media(media_type="unsupported", user_number=...)` para audit.
+2. Use a `suggested_reply_pt_br` retornada como base e **convide explicitamente o cidadão a enviar o endereço em texto** (rua, número, bairro). Não assuma de antemão que é localização — deixe a porta aberta para outros conteúdos ("se for outra coisa, descreva em texto").
+3. **Quando o cidadão responder com um endereço** no próximo turno, chame a tool MCP `validate_address(address=<texto-do-endereço>)` para converter em lat/lng + dados IPP estruturados.
+4. Com lat/lng em mãos, prossiga com o caso de uso original — por exemplo equipamentos próximos via `equipments_by_address` (que aceita o mesmo endereço-texto que você acabou de validar), alerta hídrico via `report_incident`, etc. Para o cidadão, o resultado é equivalente a ter compartilhado a localização: a Prefeitura "recebeu" a coordenada.
+
+Exemplo de turno do cidadão (resposta esperada do bot):
+
+```
+Recebi sua mensagem! Vi que você tentou compartilhar algo que não consigo
+processar diretamente por aqui — provavelmente uma localização. Pode me
+passar o endereço em texto? Algo como "Rua Tal, 123, Tijuca". Se for outro
+conteúdo, descreve em texto que eu te ajudo.
+```
+
+Quando o cidadão responder no turno seguinte (ex: "Rua das Laranjeiras 250, Laranjeiras"), chame:
+
+```
+validate_address(address="Rua das Laranjeiras 250, Laranjeiras")
+```
+
+Retorno típico inclui `latitude`, `longitude`, `bairro_id_ipp`, `logradouro_id_ipp` — dados suficientes para SGRC e raciocínio espacial. Use-os no fluxo de atendimento normal.
+
+**Não invente coordenadas.** Se `validate_address` falhar (`valid: false`), peça ao cidadão que confirme/refine o endereço.
 
 ### Exemplo
 


### PR DESCRIPTION
## Contexto

`prefeitura-rio/study-sf-whatsapp-poc1` ADR-013 (commit `7b419e9`, merged em `main`) destrava localização inbound contornando o BSP-managed em vez de mexer no canal. Bruno confirmou em 2026-05-12 que destravar suporte a `WHATSAPP_LOCATION_MESSAGE` no canal BSP-managed atual não é viável no curto prazo.

Fluxo end-to-end pós-ADR-013:

```
cidadão envia pin → BSP injeta magic string como EndUser entry
  → Apex classifica Unsupported + persiste audit
  → Apex ENCAMINHA ao Mule com message_type="unsupported"
  → Mule normaliza payload (descarta magic string, injeta placeholder PT-BR)
  → Gateway adiciona prefix [INBOUND_MEDIA] type=unsupported
  → Engine (este PR) orienta LLM a pedir endereço + chamar validate_address
  → cidadão responde com endereço em texto
  → LLM chama validate_address (tool MCP já existente)
  → MCP RECEBE lat/lng + dados IPP estruturados
  → fluxo prossegue (equipamentos próximos, alerta COR, etc.)
```

## Mudança neste PR

Extensão do prompt module `media_inbound` (não cria módulo novo — aproveita o existente, ordem em `ENABLED_MODULES` preservada).

Adiciona seção "Caso especial: `media_type=unsupported` (geocoding via texto)" que:
1. Mantém a chamada `register_inbound_media` para audit.
2. Instrui LLM a convidar endereço em texto deixando porta aberta para outros conteúdos.
3. No turno seguinte, instrui chamada `validate_address(address=...)`.
4. Após validação, sugere prosseguir com `equipments_by_address`, `report_incident`, etc.

## Custo zero de infraestrutura

- Tool MCP `validate_address` já existia (`prefeitura-rio/app-mcp-server` `src/app.py:521`) e já fazia geocoding com IPP para o fluxo SGRC. Reuso direto.
- Sem novas credenciais, sem novo deploy de MCP-tool layer.

## Mudança coordenada no MCP

`prefeitura-rio/app-mcp-server` PR (paralelo, na branch `feat/inbound-media-unsupported-invite-address`): atualiza `_SUGGESTED_REPLIES_PT_BR["unsupported"]` em `src/tools/inbound_media.py` pra alinhar o `suggested_reply_pt_br` que `register_inbound_media` retorna com o novo fluxo (convidar endereço em vez do texto fechado anterior).

## Validação

- Codex review `--uncommitted` sem findings remanescentes.
- Smoke E2E manual planejado: cidadão envia pin → bot responde em PT-BR convidando endereço → cidadão digita "Rua das Laranjeiras 250, Laranjeiras" → bot chama `validate_address` → resposta espacialmente-aware.

## Refs

- `prefeitura-rio/study-sf-whatsapp-poc1` commit `7b419e9` — ADR-013 + Apex/Mule
- `prefeitura-rio/study-sf-whatsapp-poc1/docs/decisoes/013-location-fallback-via-text-geocoding.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)