### PR TITLE
feat: cherry-pick prompt_modules pra master (deploy staging)

### DIFF
--- a/src/prompt.py
+++ b/src/prompt.py
@@ -1,4 +1,5 @@
 from src.config import env
+from src.prompt_modules import compose as compose_modules
 from loguru import logger
 import httpx
 import asyncio
@@ -45,7 +46,31 @@ async def get_system_prompt_from_api(agent_type: str = "agentic_search") -> dict
         }
 
 
-prompt_data = asyncio.run(get_system_prompt_from_api())
+def _load_composed_prompt_data() -> dict:
+    """Busca o prompt base via API e aplica os módulos enabled em código.
+
+    Encapsula a composição em função pra (1) facilitar testes que precisam
+    injetar prompt base stub via monkeypatch sem mexer no estado de módulo,
+    (2) deixar a intenção explícita no top-level.
+
+    Returns:
+        dict no mesmo schema que ``get_system_prompt_from_api`` retorna
+        (``{"prompt": str, "version": str}``), mas com ``prompt`` e
+        ``version`` aumentados pelos módulos de ``src.prompt_modules``.
+    """
+    base = asyncio.run(get_system_prompt_from_api())
+    augmented_prompt, augmented_version = compose_modules(
+        base["prompt"], base["version"]
+    )
+    if augmented_version != base["version"]:
+        logger.info(
+            f"Prompt composto com módulos: version base={base['version']} "
+            f"→ augmented={augmented_version} (delta+{len(augmented_prompt) - len(base['prompt'])} chars)"
+        )
+    return {**base, "prompt": augmented_prompt, "version": augmented_version}
+
+
+prompt_data = _load_composed_prompt_data()
 
 # PROMPT_PROVISORIO = """
 # # Persona, Tom e Estilo de Comunicação

--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -1,0 +1,75 @@
+"""
+Prompt modules — instruções de system prompt mantidas em código (vs no backing
+store da API `/eai-agent/api/v1/system-prompt`).
+
+Cada módulo é um arquivo Python que expõe duas constantes:
+
+    MODULE_NAME: str
+        Identificador único do módulo (ex: ``"media_inbound"``). Aparece no
+        version do prompt final (ex: ``"2026.05.12.1+media_inbound"``) pra
+        tornar a composição visível em logs e métricas OTel.
+    MODULE_PROMPT: str
+        Markdown a ser appendado ao prompt base, separado por ``\\n\\n``.
+
+A função :func:`compose` aplica os módulos listados em ``ENABLED_MODULES``
+nessa ordem em cima do prompt base obtido da API.
+
+Por que módulos em código (e não no backing store):
+
+* **Versionável via git**: cada mudança gera diff revisável em PR.
+* **Acoplado ao código que ele exige**: instruções pra chamar uma tool MCP
+  mudam junto com a versão da tool (ex: novo campo na assinatura).
+* **Não exige write-access ao backing store**: equipes downstream
+  conseguem evoluir as instruções sem dependência da equipe que mantém a
+  API de prompts.
+
+O prompt base continua sendo a fonte autoritativa de comportamento geral do
+agente (tom, escopo, fallbacks). Os módulos cobrem apenas integrações
+específicas que devem viver ao lado do código de tools.
+"""
+
+from typing import Tuple
+
+from src.prompt_modules import media_inbound
+
+# Ordem importa — define a sequência em que cada módulo aparece no prompt
+# final. Pra desabilitar um módulo, removê-lo desta lista (não comentar
+# import, pra evitar drift).
+ENABLED_MODULES = [
+    media_inbound,
+]
+
+
+def compose(base_prompt: str, base_version: str) -> Tuple[str, str]:
+    """
+    Append os módulos enabled ao prompt base e retorna prompt+version composto.
+
+    Args:
+        base_prompt: conteúdo bruto retornado pela API de system prompt.
+        base_version: versão retornada pela API (ex: ``"2026.05.12.1"`` ou
+            ``"FallBack"`` quando a API falha).
+
+    Returns:
+        Tuple ``(augmented_prompt, augmented_version)``.
+
+        Quando ``ENABLED_MODULES`` está vazio, retorna o par original sem
+        alteração (backward-compat se todos os módulos forem desligados).
+
+        Quando há módulos, ``augmented_version`` ganha sufixo no formato
+        ``"<base_version>+<mod1>+<mod2>+..."`` na ordem de ``ENABLED_MODULES``.
+    """
+    if not ENABLED_MODULES:
+        return base_prompt, base_version
+
+    parts = [base_prompt]
+    suffixes = []
+    for mod in ENABLED_MODULES:
+        parts.append(mod.MODULE_PROMPT)
+        suffixes.append(mod.MODULE_NAME)
+
+    augmented_prompt = "\n\n".join(parts)
+    augmented_version = f"{base_version}+{'+'.join(suffixes)}"
+    return augmented_prompt, augmented_version
+
+
+__all__ = ["compose", "ENABLED_MODULES"]

--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -30,13 +30,19 @@ específicas que devem viver ao lado do código de tools.
 
 from typing import Tuple
 
-from src.prompt_modules import media_inbound
+from src.prompt_modules import media_inbound, vision_inbound
 
 # Ordem importa — define a sequência em que cada módulo aparece no prompt
 # final. Pra desabilitar um módulo, removê-lo desta lista (não comentar
 # import, pra evitar drift).
+#
+# vision_inbound depende semanticamente de media_inbound (refere o protocolo
+# do ``[INBOUND_MEDIA]`` definido lá), portanto vem DEPOIS. O suggested_reply
+# do analyze_inbound_image substitui o do register_inbound_media — a ordem
+# das instruções no prompt importa pro LLM resolver o "qual usar".
 ENABLED_MODULES = [
     media_inbound,
+    vision_inbound,
 ]
 
 

--- a/src/prompt_modules/media_inbound.py
+++ b/src/prompt_modules/media_inbound.py
@@ -1,0 +1,123 @@
+"""
+Módulo de prompt: instruções para o LLM detectar o prefix ``[INBOUND_MEDIA]``
+e invocar a tool MCP ``register_inbound_media``.
+
+Contexto do fluxo upstream (de cidadão até este módulo):
+
+1. Cidadão envia mídia (imagem ou áudio) pelo WhatsApp.
+2. Salesforce UWC entrega via Connect API; Apex
+   ``SCConnectFetchQueueable`` (em ``prefeitura-rio/study-sf-whatsapp-poc1``)
+   classifica como ``Image``/``Audio``/``Unsupported``/``Unknown`` e
+   correlaciona ``ContentVersion`` via two-pointer.
+3. Mule ``sc-inbound-flow.xml`` propaga ``message_type`` + ``media`` no
+   ``POST /api/v1/message/webhook/user`` do gateway.
+4. Gateway (``prefeitura-rio/app-eai-agent-gateway``, PR #25) enriquece o
+   ``content`` da mensagem humana com o prefix:
+
+       [INBOUND_MEDIA] type=<mt> user_number=<phone> media=<json> | user_text=<original>
+
+5. Engine LangGraph (este repo) entrega esse content como ``HumanMessage`` ao
+   LLM Gemini 2.5 Flash. Sem instruções específicas, o LLM trataria como
+   texto qualquer e ignoraria o prefix.
+
+Este módulo injeta as instruções faltando, na ordem definida em
+``src.prompt_modules.ENABLED_MODULES``.
+
+Tool MCP correspondente: ``register_inbound_media`` em
+``prefeitura-rio/app-mcp-server`` (merge commit ``413ecb0``), arquivo
+``src/tools/inbound_media.py``. Stub-de-recepção atual:
+loga audit + retorna ``suggested_reply_pt_br`` PT-BR. Análise visual,
+transcrição e geocoding ficam para fases posteriores.
+
+ADR de referência: ADR-012 em ``study-sf-whatsapp-poc1`` — decisões
+empíricas sobre auto-attach de ``ContentVersion`` pelo bridge UWC e
+limitações do BSP atual para localização.
+"""
+
+MODULE_NAME = "media_inbound"
+
+MODULE_PROMPT = """## Recepção de mídia (imagem, áudio, localização)
+
+Quando a entrada do cidadão começar com `[INBOUND_MEDIA]`, **NÃO** trate como texto normal. Em vez disso, siga este protocolo:
+
+1. **Parse o prefix.** Formato:
+
+   ```
+   [INBOUND_MEDIA] type=<media_type> user_number=<phone> media=<json> | user_text=<placeholder>
+   ```
+
+   - `media_type` ∈ `{image, audio, location, unsupported, unknown}`
+   - `user_number`: E.164 sem `+` (ex: `5521989091014`)
+   - `media`: objeto JSON com metadados (pode ser `null` para `unsupported`/`unknown`)
+   - `user_text`: conteúdo textual associado à mídia. **Atenção:** pode ser **placeholder gerado upstream** (quando nada de texto real veio do cidadão) ou **conteúdo real** (caption de imagem, transcrição de áudio, etc.).
+     - **Considere placeholder/sem-conteúdo-real** quando: (a) string vazia/só whitespace, (b) começa com `[Cidadao enviou ` (sem acento), (c) começa com `[Cidadão enviou ` (com acento), (d) começa com `[INBOUND_MEDIA`. Ignore para fins de raciocínio. (O Mule envia atualmente sem acento; o pattern com acento fica reservado pra evolução futura do gateway.)
+     - Caso contrário, trate como mensagem real do cidadão associada à mídia.
+
+2. **Chame imediatamente a tool `register_inbound_media`** com:
+
+   - `media_type`: o valor extraído de `type=`
+   - `user_number`: o valor extraído de `user_number=`
+   - Para `image`/`audio`/`unknown` (quando `media` tem conteúdo):
+     - `content_version_id`, `file_extension`, `file_size_bytes`, `salesforce_download_path` (do campo `download_path`) — extraídos do JSON `media`
+   - Para `location` (quando suporte do canal habilitar lat/lng):
+     - `latitude`, `longitude`, `address` — do JSON `media`
+   - Para `unsupported`: chame com apenas `media_type` + `user_number`
+
+3. **Componha a resposta ao cidadão** levando em conta o conteúdo de `user_text` extraído no passo 1:
+
+   - **Se `user_text` é placeholder ou vazio** (vazio/whitespace, ou começa com `[Cidadao enviou ` / `[Cidadão enviou ` / `[INBOUND_MEDIA`): use o campo `suggested_reply_pt_br` retornado pela tool como base — ele já tem mensagem amigável + chamada-para-ação. Adapte o tom ao contexto da conversa.
+   - **Se `user_text` é conteúdo real do cidadão** (caption de imagem ou transcrição de áudio): **NÃO** peça pra repetir a informação. Continue o atendimento normalmente usando o `user_text` como parte da mensagem do cidadão; o registro da mídia via tool fica só como audit. Pode mencionar brevemente que recebeu o anexo, mas não bloqueie o fluxo.
+
+4. **Não tente analisar a imagem/áudio nem geocodificar.** A tool atual é stub de recepção (apenas registra audit + retorna sugestão). Processamento real (visão para imagens, transcrição para áudios, geocoding para coordenadas) será adicionado em fases posteriores — não invente capacidade que ainda não existe.
+
+### Exemplo
+
+Entrada do cidadão:
+
+```
+[INBOUND_MEDIA] type=image user_number=5521989091014 media={"content_version_id":"0688800000Bgd3T","content_document_id":"0698800000BR4R0","file_extension":"jpg","file_size_bytes":119900,"download_path":"/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3T/VersionData"} | user_text=[Cidadao enviou uma imagem. Suporte a analise visual em desenvolvimento — pedir descricao em texto.]
+```
+
+Note que o JSON `media` pode conter campos extras (`content_document_id`, `mime_type`, etc.) que **não são** parâmetros aceitos pela tool — ignore esses e passe apenas os parâmetros documentados acima.
+
+Sua chamada de tool:
+
+```
+register_inbound_media(
+    media_type="image",
+    user_number="5521989091014",
+    content_version_id="0688800000Bgd3T",
+    file_extension="jpg",
+    file_size_bytes=119900,
+    salesforce_download_path="/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3T/VersionData",
+)
+```
+
+Retorno típico:
+
+```json
+{
+  "status": "received",
+  "media_type": "image",
+  "processing": "deferred",
+  "suggested_reply_pt_br": "Recebi sua imagem! No momento ainda não consigo analisar fotos. Pode descrever em texto o que precisa pra eu te ajudar?"
+}
+```
+
+Como o `user_text` deste exemplo é placeholder (começa com `[Cidadao enviou `), você usa o `suggested_reply_pt_br` como base:
+
+> Recebi sua foto! Ainda não consigo analisar imagens diretamente, mas se você me contar em texto o que precisa eu te ajudo no que der.
+
+### Exemplo com user_text real (transcrição de áudio)
+
+Entrada:
+
+```
+[INBOUND_MEDIA] type=audio user_number=5521989091014 media={"content_version_id":"068...","file_extension":"oga","file_size_bytes":14509,"download_path":"/services/data/v62.0/sobjects/ContentVersion/068.../VersionData"} | user_text=tem uma luminária queimada na rua das laranjeiras
+```
+
+Você ainda chama `register_inbound_media` para audit. Mas o `user_text` é conteúdo real — **não peça pra repetir**. Resposta:
+
+> Anotei o relato (recebi também o áudio). Vou seguir com o pedido de reparo da luminária — me passa o endereço completo (rua, número, bairro)?
+
+"""

--- a/src/prompt_modules/media_inbound.py
+++ b/src/prompt_modules/media_inbound.py
@@ -68,7 +68,37 @@ Quando a entrada do cidadão começar com `[INBOUND_MEDIA]`, **NÃO** trate como
    - **Se `user_text` é placeholder ou vazio** (vazio/whitespace, ou começa com `[Cidadao enviou ` / `[Cidadão enviou ` / `[INBOUND_MEDIA`): use o campo `suggested_reply_pt_br` retornado pela tool como base — ele já tem mensagem amigável + chamada-para-ação. Adapte o tom ao contexto da conversa.
    - **Se `user_text` é conteúdo real do cidadão** (caption de imagem ou transcrição de áudio): **NÃO** peça pra repetir a informação. Continue o atendimento normalmente usando o `user_text` como parte da mensagem do cidadão; o registro da mídia via tool fica só como audit. Pode mencionar brevemente que recebeu o anexo, mas não bloqueie o fluxo.
 
-4. **Não tente analisar a imagem/áudio nem geocodificar.** A tool atual é stub de recepção (apenas registra audit + retorna sugestão). Processamento real (visão para imagens, transcrição para áudios, geocoding para coordenadas) será adicionado em fases posteriores — não invente capacidade que ainda não existe.
+4. **Não tente analisar a imagem/áudio.** A tool `register_inbound_media` é stub de recepção (apenas registra audit + retorna sugestão). Processamento de imagem usa a tool separada `analyze_inbound_image` (quando disponível, conforme módulo `vision_inbound`). Transcrição de áudio será adicionada em fases posteriores — não invente capacidade que ainda não existe.
+
+### Caso especial: `media_type=unsupported` (geocoding via texto)
+
+Quando `media_type=unsupported`, o canal BSP-managed bloqueou o conteúdo que o cidadão tentou enviar. **A causa predominante é tentativa de compartilhar localização** (pin de mapa), mas pode também ser vídeo, sticker, documento, etc. Bruno confirmou em 2026-05-12 que destravar o canal BSP-side não é viável no curto prazo (ver ADR-013 em `study-sf-whatsapp-poc1`).
+
+Fluxo correto:
+
+1. Chame `register_inbound_media(media_type="unsupported", user_number=...)` para audit.
+2. Use a `suggested_reply_pt_br` retornada como base e **convide explicitamente o cidadão a enviar o endereço em texto** (rua, número, bairro). Não assuma de antemão que é localização — deixe a porta aberta para outros conteúdos ("se for outra coisa, descreva em texto").
+3. **Quando o cidadão responder com um endereço** no próximo turno, chame a tool MCP `validate_address(address=<texto-do-endereço>)` para converter em lat/lng + dados IPP estruturados.
+4. Com lat/lng em mãos, prossiga com o caso de uso original — por exemplo equipamentos próximos via `equipments_by_address` (que aceita o mesmo endereço-texto que você acabou de validar), alerta hídrico via `report_incident`, etc. Para o cidadão, o resultado é equivalente a ter compartilhado a localização: a Prefeitura "recebeu" a coordenada.
+
+Exemplo de turno do cidadão (resposta esperada do bot):
+
+```
+Recebi sua mensagem! Vi que você tentou compartilhar algo que não consigo
+processar diretamente por aqui — provavelmente uma localização. Pode me
+passar o endereço em texto? Algo como "Rua Tal, 123, Tijuca". Se for outro
+conteúdo, descreve em texto que eu te ajudo.
+```
+
+Quando o cidadão responder no turno seguinte (ex: "Rua das Laranjeiras 250, Laranjeiras"), chame:
+
+```
+validate_address(address="Rua das Laranjeiras 250, Laranjeiras")
+```
+
+Retorno típico inclui `latitude`, `longitude`, `bairro_id_ipp`, `logradouro_id_ipp` — dados suficientes para SGRC e raciocínio espacial. Use-os no fluxo de atendimento normal.
+
+**Não invente coordenadas.** Se `validate_address` falhar (`valid: false`), peça ao cidadão que confirme/refine o endereço.
 
 ### Exemplo
 

--- a/src/prompt_modules/vision_inbound.py
+++ b/src/prompt_modules/vision_inbound.py
@@ -1,0 +1,154 @@
+"""
+Módulo de prompt: instruções para o LLM chamar a tool MCP
+``analyze_inbound_image`` (Gemini Vision) depois de ``register_inbound_media``
+quando o cidadão envia uma imagem via WhatsApp.
+
+Contexto:
+
+* :mod:`src.prompt_modules.media_inbound` já instrui o LLM a chamar
+  ``register_inbound_media`` (stub de recepção/audit) quando vê o prefix
+  ``[INBOUND_MEDIA]``. Esse stub registra mas não analisa.
+* A tool MCP ``analyze_inbound_image`` (em
+  ``prefeitura-rio/app-mcp-server`` commit ``71202f62``, arquivo
+  ``src/tools/inbound_media_vision.py``) faz análise visual real via
+  Gemini Vision e classifica em workflows (``reparo_luminaria``,
+  ``poda_de_arvore``, ``nenhum``). É **opt-in** no MCP via flag
+  ``ENABLE_VISION_ADDENDUM=true`` — sem o flag a tool não é registrada e
+  o LLM nem a vê (instruções abaixo viram no-op).
+
+Quando a tool está registrada, o LLM deve chamar ela DEPOIS do
+``register_inbound_media`` mas ANTES de responder ao cidadão. O
+``suggested_reply_pt_br`` da análise visual substitui o do registro stub.
+
+**Limitação conhecida (fase atual):** ``analyze_inbound_image`` requer
+``image_bytes_base64`` ou ``local_image_path``. Em produção via Engine,
+nenhum dos dois é fornecido automaticamente pelo Gateway hoje (só
+``salesforce_download_path``). Até o Engine team implementar pré-fetch
+de bytes do Salesforce e injeção no contexto da mensagem, a tool pode
+retornar erro/análise vazia em prod. Mantemos a instrução pro LLM
+porque (a) staging com upload manual de bytes funciona, (b) quando o
+pre-fetch chegar (fase 2), nenhum redeploy de prompt será necessário.
+
+Refs:
+    - ``prefeitura-rio/app-mcp-server`` merge commit ``71202f62`` (PR #56)
+    - ``prefeitura-rio/study-sf-whatsapp-poc1`` ADR-012
+    - ``src/prompt_modules/media_inbound.py`` (módulo predecessor)
+"""
+
+MODULE_NAME = "vision_inbound"
+
+MODULE_PROMPT = """## Análise visual de imagem inbound (extensão de mídia)
+
+Quando o passo anterior identificou ``media_type=image`` (via
+``register_inbound_media`` do módulo "Recepção de mídia"), você PODE
+tentar análise visual via ``analyze_inbound_image``. Decisão sobre
+chamá-la ou não segue a árvore abaixo:
+
+### Decisão: chamar ``analyze_inbound_image`` ou pular?
+
+**Chamar somente se TODAS as 2 condições forem verdadeiras:**
+
+(a) A tool ``analyze_inbound_image`` está disponível no seu toolset
+    (opt-in via ``ENABLE_VISION_ADDENDUM=true`` no MCP — se a tool não
+    estiver listada, ela não está disponível).
+
+(b) Você tem acesso aos bytes da imagem em uma destas formas:
+    - ``image_bytes_base64`` no contexto da mensagem (modo produção
+      fase 2, quando Engine pré-baixar do Salesforce)
+    - ``local_image_path`` no JSON do prefix ``[INBOUND_MEDIA]`` (modo
+      teste local com upload manual)
+
+**Se qualquer uma das 2 condições falhar, NÃO chame a tool.** Volte
+inteiramente ao protocolo do módulo "Recepção de mídia" — ele já trata
+corretamente a distinção entre placeholder (use ``suggested_reply_pt_br``
+do registro) vs caption real (use o ``user_text`` como mensagem do
+cidadão, sem pedir pra repetir). Não há regressão nesse caminho.
+
+> ``salesforce_download_path`` sozinho NÃO basta — ``analyze_inbound_image``
+> não baixa do Salesforce. Chamar a tool sem ``image_bytes_base64`` nem
+> ``local_image_path`` causa erro/análise vazia; melhor pular.
+
+### Quando AS DUAS condições passam, executar análise
+
+1. **Chamar ``analyze_inbound_image``** logo após o ``register_inbound_media``:
+
+   - ``user_number``: mesmo valor extraído do prefix ``[INBOUND_MEDIA]``
+   - ``file_extension``: do campo ``media.file_extension``
+   - ``message_id``: do prefix se disponível (audit cross-ref)
+   - ``content_version_id``: do campo ``media.content_version_id``
+   - ``image_bytes_base64`` OU ``local_image_path`` (pelo menos um)
+
+2. **Usar a resposta da análise.** O retorno contém ``analysis`` com:
+
+   - ``descricao``: o que a foto mostra
+   - ``problema_detectado``: bool
+   - ``categoria``: ``luminaria_publica``/``poda_arvore``/``buraco_via``/etc.
+   - ``workflow_sugerido``: ``reparo_luminaria``/``poda_de_arvore``/``nenhum``
+   - ``confianca``: ``alta``/``media``/``baixa``
+
+   E ``suggested_reply_pt_br`` baseado na análise. Use **esse**
+   ``suggested_reply_pt_br`` (da análise visual) como base da resposta
+   ao cidadão — NÃO o do ``register_inbound_media``, que é genérico.
+
+   Se ``user_text`` veio com caption real do cidadão, **combine**: cite
+   tanto o que viu na imagem quanto o que o cidadão disse, sem pedir
+   pra ele repetir o que já escreveu.
+
+3. **Iniciar workflow se aplicável.** Se
+   ``analysis.workflow_sugerido`` for ``reparo_luminaria`` ou
+   ``poda_de_arvore`` E a ``confianca`` for ``alta`` ou ``media``:
+
+   - Confirme com o cidadão a categoria detectada antes de iniciar o
+     workflow ("Vi uma luminária com o globo quebrado — confirma que
+     é isso?").
+   - Após confirmação, inicie via ``multi_step_service`` com o
+     ``service_name`` correspondente.
+
+4. **Fallback se análise falha ou é inconclusiva.** Se a tool retornar
+   erro, ``problema_detectado=false`` com ``categoria=nao_aplica``, ou
+   ``confianca=baixa``, **volte ao protocolo do módulo "Recepção de
+   mídia"** (mesmo princípio do "tool indisponível" acima — não invente
+   diagnóstico não suportado pela análise; se há ``user_text`` real,
+   continue a partir dele).
+
+### Exemplo de fluxo (imagem de luminária quebrada)
+
+Após ``register_inbound_media`` ter sido chamado para a imagem,
+você chama:
+
+```
+analyze_inbound_image(
+    user_number="5521989091014",
+    file_extension="jpg",
+    content_version_id="0688800000Bgd3T",
+    image_bytes_base64="<bytes do contexto>",
+)
+```
+
+Retorno típico:
+
+```json
+{
+  "status": "ok",
+  "analysis": {
+    "descricao": "Poste de luminária pública com lâmpada quebrada",
+    "problema_detectado": true,
+    "categoria": "luminaria_publica",
+    "detalhes": "Vidro do globo da luminária quebrado, lâmpada visível",
+    "workflow_sugerido": "reparo_luminaria",
+    "confianca": "alta"
+  },
+  "suggested_reply_pt_br": "Vi na foto que a luminária pública está com o globo quebrado. Posso abrir o pedido de reparo pra você? Me confirma o endereço (rua, número, bairro) e a gente segue."
+}
+```
+
+Sua resposta ao cidadão (adaptando o ``suggested_reply_pt_br``):
+
+> Olhei sua foto — luminária com globo quebrado, anotado.
+> Pra abrir o pedido de reparo preciso do endereço (rua, número, bairro).
+> Pode me passar?
+
+Depois da confirmação do endereço, chame
+``multi_step_service(service_name="reparo_luminaria", user_id=user_number, payload=...)``
+pra iniciar o workflow.
+"""

--- a/tests/unit/test_prompt_modules.py
+++ b/tests/unit/test_prompt_modules.py
@@ -9,7 +9,7 @@ tests pós-deploy em staging.
 """
 
 from src.prompt_modules import compose, ENABLED_MODULES
-from src.prompt_modules import media_inbound
+from src.prompt_modules import media_inbound, vision_inbound
 
 
 # ---------- compose() — comportamento básico ----------
@@ -181,6 +181,72 @@ def test_media_inbound_prompt_omits_unsupported_tool_params_in_call():
         f"Prompt usa {forbidden!r} em chamada da tool, "
         "mas a tool não aceita esse parâmetro"
     )
+
+
+# ---------- módulo vision_inbound ----------
+
+
+def test_vision_inbound_module_has_required_attributes():
+    """vision_inbound deve seguir o mesmo contrato dos outros módulos."""
+    assert hasattr(vision_inbound, "MODULE_NAME")
+    assert hasattr(vision_inbound, "MODULE_PROMPT")
+    assert isinstance(vision_inbound.MODULE_NAME, str)
+    assert isinstance(vision_inbound.MODULE_PROMPT, str)
+
+
+def test_vision_inbound_module_name_is_stable():
+    """MODULE_NAME do vision_inbound vira sufixo no version (e em logs OTel)."""
+    assert vision_inbound.MODULE_NAME == "vision_inbound"
+
+
+def test_vision_inbound_prompt_mentions_analyze_tool():
+    """Sanity: prompt deve nomear a tool MCP `analyze_inbound_image` que
+    deve ser chamada — sem isso, o LLM não sabe o nome exato e pode
+    chutar ou nem tentar."""
+    p = vision_inbound.MODULE_PROMPT
+    assert "analyze_inbound_image" in p, "Nome da tool MCP de visão ausente"
+    assert "register_inbound_media" in p, "Referência à tool antecedente ausente"
+
+
+def test_vision_inbound_prompt_handles_opt_in_fallback():
+    """A tool é opt-in (ENABLE_VISION_ADDENDUM=true no MCP). Quando não
+    registrada, LLM nem vê o nome. Mas o prompt precisa instruir o
+    fallback explícito pra esse caso pra evitar travamento."""
+    p = vision_inbound.MODULE_PROMPT.lower()
+    assert "indisponível" in p or "indisponivel" in p or "disponível" in p, (
+        "Falta instrução sobre comportamento quando tool não está registrada"
+    )
+
+
+def test_vision_inbound_prompt_warns_about_missing_bytes():
+    """analyze_inbound_image NÃO baixa do Salesforce — precisa de
+    image_bytes_base64 OU local_image_path. Sem nenhum dos dois, ela
+    falha. Prompt deve avisar pra LLM não chamar sem bytes."""
+    p = vision_inbound.MODULE_PROMPT
+    assert "salesforce_download_path" in p, "Path do SF não documentado"
+    assert "image_bytes_base64" in p, "Bytes em base64 não documentados"
+    assert "local_image_path" in p, "Path local não documentado"
+
+
+def test_vision_module_appears_after_media_module_in_enabled():
+    """vision_inbound depende semanticamente de media_inbound — a ordem
+    das instruções no prompt importa pro LLM resolver "qual reply usar"
+    (vision suggested_reply substitui o do register stub)."""
+    names = [m.MODULE_NAME for m in ENABLED_MODULES]
+    assert "media_inbound" in names
+    assert "vision_inbound" in names
+    assert names.index("media_inbound") < names.index("vision_inbound"), (
+        "vision_inbound deve vir DEPOIS de media_inbound em ENABLED_MODULES"
+    )
+
+
+def test_vision_inbound_workflow_suggestions_in_prompt():
+    """Os workflows que a análise visual pode sugerir devem estar
+    documentados no prompt pra o LLM saber qual chamar via
+    `multi_step_service`."""
+    p = vision_inbound.MODULE_PROMPT
+    for workflow in ["reparo_luminaria", "poda_de_arvore"]:
+        assert workflow in p, f"workflow '{workflow}' não documentado"
 
 
 # ---------- regressão: idempotência de chamada ----------

--- a/tests/unit/test_prompt_modules.py
+++ b/tests/unit/test_prompt_modules.py
@@ -1,0 +1,195 @@
+"""
+Testes do mecanismo de composição de prompt modules
+(``src.prompt_modules``).
+
+Estes testes não dependem da API de prompt (``EAI_AGENT_URL``) e não exigem
+credenciais GCP — exercitam apenas a lógica de composição pura. Para validar
+o end-to-end (prompt fetched → composto → entregue ao agent), usar smoke
+tests pós-deploy em staging.
+"""
+
+from src.prompt_modules import compose, ENABLED_MODULES
+from src.prompt_modules import media_inbound
+
+
+# ---------- compose() — comportamento básico ----------
+
+
+def test_compose_returns_pair_of_strings():
+    augmented, version = compose("BASE", "v1.0")
+    assert isinstance(augmented, str)
+    assert isinstance(version, str)
+
+
+def test_compose_preserves_base_prompt_content():
+    base = "Você é assistente da Prefeitura."
+    augmented, _ = compose(base, "v1.0")
+    assert base in augmented, "Conteúdo do prompt base não pode ser perdido"
+
+
+def test_compose_appends_modules_after_base():
+    base = "Base do prompt."
+    augmented, _ = compose(base, "v1.0")
+    # módulos aparecem depois do base
+    base_idx = augmented.index(base)
+    for mod in ENABLED_MODULES:
+        mod_idx = augmented.index(mod.MODULE_PROMPT)
+        assert mod_idx > base_idx, (
+            f"Módulo {mod.MODULE_NAME} apareceu antes do base"
+        )
+
+
+def test_compose_separates_with_blank_line():
+    base = "Base."
+    augmented, _ = compose(base, "v1.0")
+    # Cada módulo deve estar separado por linha em branco (markdown sectioning)
+    assert "\n\n" in augmented
+
+
+def test_compose_version_appends_module_names():
+    _, version = compose("BASE", "v1.0")
+    assert version.startswith("v1.0+")
+    for mod in ENABLED_MODULES:
+        assert mod.MODULE_NAME in version
+
+
+def test_compose_version_order_matches_modules_order():
+    _, version = compose("BASE", "v1.0")
+    expected_suffix = "+".join(m.MODULE_NAME for m in ENABLED_MODULES)
+    assert version == f"v1.0+{expected_suffix}"
+
+
+# ---------- compose() — edge cases ----------
+
+
+def test_compose_with_fallback_version_string():
+    """Se a API estiver fora e o base for o fallback, version segue compose."""
+    _, version = compose("fallback prompt", "FallBack")
+    assert version.startswith("FallBack+")
+
+
+def test_compose_with_empty_base_prompt():
+    """Caller pode passar string vazia (cenário improvável mas defensivo)."""
+    augmented, _ = compose("", "v0")
+    # Não dá erro; resultado começa com \n\n + módulos
+    for mod in ENABLED_MODULES:
+        assert mod.MODULE_PROMPT in augmented
+
+
+def test_compose_with_no_modules_is_passthrough(monkeypatch):
+    """
+    Se ``ENABLED_MODULES`` for esvaziado (todos os módulos desligados),
+    compose vira pass-through completo: prompt e version inalterados.
+    """
+    import src.prompt_modules as mods
+
+    monkeypatch.setattr(mods, "ENABLED_MODULES", [])
+    augmented, version = mods.compose("BASE", "v1.0")
+    assert augmented == "BASE"
+    assert version == "v1.0"
+
+
+# ---------- contract dos módulos individuais ----------
+
+
+def test_media_inbound_module_has_required_attributes():
+    """Cada módulo deve expor ``MODULE_NAME`` e ``MODULE_PROMPT`` (contrato
+    consumido por ``compose``)."""
+    assert hasattr(media_inbound, "MODULE_NAME")
+    assert hasattr(media_inbound, "MODULE_PROMPT")
+    assert isinstance(media_inbound.MODULE_NAME, str)
+    assert isinstance(media_inbound.MODULE_PROMPT, str)
+
+
+def test_media_inbound_module_name_is_stable():
+    """``MODULE_NAME`` vira sufixo no version do prompt — não pode mudar
+    silenciosamente porque quebra dashboards/logs OTel que filtram por
+    version."""
+    assert media_inbound.MODULE_NAME == "media_inbound"
+
+
+def test_media_inbound_prompt_mentions_protocol_keywords():
+    """Sanity: o prompt deve instruir sobre os 3 elementos essenciais
+    (prefix, tool e campo de resposta sugerida). Não é teste de conteúdo
+    pleno — é guard contra deleção acidental dos pilares."""
+    p = media_inbound.MODULE_PROMPT
+    assert "[INBOUND_MEDIA]" in p, "Prefix de detecção ausente"
+    assert "register_inbound_media" in p, "Nome da tool MCP ausente"
+    assert "suggested_reply_pt_br" in p, "Campo de resposta sugerida ausente"
+
+
+def test_media_inbound_prompt_lists_all_media_types():
+    """Os 5 valores válidos de ``media_type`` que o tool MCP aceita devem
+    aparecer no prompt — senão o LLM pode rejeitar ou usar tipo errado."""
+    p = media_inbound.MODULE_PROMPT
+    for media_type in ["image", "audio", "location", "unsupported", "unknown"]:
+        assert media_type in p, f"media_type '{media_type}' não documentado"
+
+
+def test_media_inbound_prompt_distinguishes_placeholder_vs_real_user_text():
+    """user_text pode ser placeholder (descartável) OU conteúdo real
+    (caption/transcrição). Sem essa distinção no prompt, o LLM pediria pro
+    cidadão repetir texto já transcrito upstream — UX ruim. Verifica que o
+    prompt instrui distinguir os dois casos."""
+    p = media_inbound.MODULE_PROMPT
+    # Instrução pra NÃO pedir repetição quando user_text é real
+    assert "NÃO" in p.upper() or "não peça" in p.lower(), (
+        "Falta instrução pra não pedir repetição em conteúdo real"
+    )
+
+
+def test_media_inbound_prompt_handles_empty_user_text_as_placeholder():
+    """Quando gateway aceita media-only sem caption, prefix vira
+    `... | user_text=`. Sem instrução explícita, esse vazio cairia pra
+    branch de "conteúdo real" — LLM ignoraria suggested_reply_pt_br."""
+    p = media_inbound.MODULE_PROMPT.lower()
+    assert "vazio" in p or "vazia" in p, (
+        "Prompt não trata user_text vazio como placeholder — "
+        "media-only sem caption vai pra branch errada"
+    )
+
+
+def test_media_inbound_prompt_covers_both_placeholder_spellings():
+    """O Mule sc-inbound-flow.xml hoje envia `[Cidadao enviou` (sem acento)
+    por causa do encoding DataWeave. O prompt precisa reconhecer ESSA forma —
+    e idealmente a com acento também, pra ficar resiliente a evoluções
+    futuras do gateway. Sem o pattern sem-acento, todo o fluxo média-only
+    cai pra branch de "user_text real" e o LLM ignora suggested_reply_pt_br."""
+    p = media_inbound.MODULE_PROMPT
+    assert "[Cidadao enviou " in p, (
+        "Pattern sem acento (atual do Mule) não documentado — "
+        "media-only flow vai cair pra branch errada"
+    )
+    assert "[Cidadão enviou " in p, (
+        "Pattern com acento não documentado — resiliência futura quebrada"
+    )
+
+
+def test_media_inbound_prompt_omits_unsupported_tool_params_in_call():
+    """O tool MCP `register_inbound_media` não aceita `content_document_id`
+    como parâmetro (apenas `content_version_id`). O prompt pode mencionar
+    `content_document_id` no JSON de entrada do prefix (lá ele aparece como
+    metadata bruta vinda do gateway), mas **NÃO** pode aparecer como
+    keyword argument na chamada de exemplo da tool — risco de o LLM emitir
+    tool call inválido.
+
+    Pattern verificado: ``content_document_id=`` (com sinal de igualdade,
+    indicando keyword arg Python-like) não pode existir no prompt."""
+    p = media_inbound.MODULE_PROMPT
+    forbidden = "content_document_id="
+    assert forbidden not in p, (
+        f"Prompt usa {forbidden!r} em chamada da tool, "
+        "mas a tool não aceita esse parâmetro"
+    )
+
+
+# ---------- regressão: idempotência de chamada ----------
+
+
+def test_compose_is_pure_and_idempotent():
+    """Chamar compose 2x com mesmos argumentos retorna mesmo resultado
+    byte-a-byte (sem efeitos colaterais em estado de módulo)."""
+    a1, v1 = compose("BASE", "v1")
+    a2, v2 = compose("BASE", "v1")
+    assert a1 == a2
+    assert v1 == v2


### PR DESCRIPTION
Cherry-pick limpo dos 3 commits prompt_modules da branch staging (PR #34 está CONFLICTING):
- #37 media_inbound (register_inbound_media)
- #39 vision_inbound (analyze_inbound_image, gated por ENABLE_VISION_ADDENDUM)
- #40 location fallback (validate_address)

Objetivo: deploy staging Engine COM os módulos. Deploy anterior (REASONING_ENGINE_ID 4414403395834609664) foi de master sem features.