### PR TITLE
feat(prompt): modulo audio_inbound + dispatcha audio/imagem em media_inbound

### DIFF
--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -30,19 +30,21 @@ específicas que devem viver ao lado do código de tools.
 
 from typing import Tuple
 
-from src.prompt_modules import media_inbound, vision_inbound
+from src.prompt_modules import audio_inbound, media_inbound, vision_inbound
 
 # Ordem importa — define a sequência em que cada módulo aparece no prompt
 # final. Pra desabilitar um módulo, removê-lo desta lista (não comentar
 # import, pra evitar drift).
 #
-# vision_inbound depende semanticamente de media_inbound (refere o protocolo
-# do ``[INBOUND_MEDIA]`` definido lá), portanto vem DEPOIS. O suggested_reply
-# do analyze_inbound_image substitui o do register_inbound_media — a ordem
-# das instruções no prompt importa pro LLM resolver o "qual usar".
+# vision_inbound e audio_inbound dependem semanticamente de media_inbound
+# (referem o protocolo do ``[INBOUND_MEDIA]`` definido lá), portanto vêm
+# DEPOIS. O suggested_reply de analyze_inbound_image/_audio substitui o do
+# register_inbound_media — a ordem das instruções no prompt importa pro LLM
+# resolver o "qual usar".
 ENABLED_MODULES = [
     media_inbound,
     vision_inbound,
+    audio_inbound,
 ]
 
 

--- a/src/prompt_modules/audio_inbound.py
+++ b/src/prompt_modules/audio_inbound.py
@@ -1,0 +1,173 @@
+"""
+Módulo de prompt: instruções para o LLM chamar a tool MCP
+``analyze_inbound_audio`` (Gemini multimodal) depois de
+``register_inbound_media`` quando o cidadão envia áudio via WhatsApp.
+
+Contexto:
+
+* :mod:`src.prompt_modules.media_inbound` já instrui o LLM a chamar
+  ``register_inbound_media`` (stub de recepção/audit) quando vê o prefix
+  ``[INBOUND_MEDIA]``. Esse stub registra mas não transcreve.
+* A tool MCP ``analyze_inbound_audio`` (em
+  ``prefeitura-rio/app-mcp-server``, arquivo
+  ``src/tools/inbound_media_audio.py``) faz transcrição real via Gemini
+  multimodal e classifica em workflows (``reparo_luminaria``,
+  ``poda_de_arvore``, ``nenhum``). É **opt-in** no MCP via flag
+  ``ENABLE_AUDIO_ADDENDUM=true`` (default-on) — sem o flag a tool não é
+  registrada e o LLM nem a vê (instruções abaixo viram no-op).
+
+Refs:
+    - ``prefeitura-rio/app-mcp-server`` PR feat/audio-transcription-via-gemini
+    - ``prefeitura-rio/study-sf-whatsapp-poc1`` ADR-015 (entrega audio E2E)
+    - ``src/prompt_modules/vision_inbound.py`` (módulo sibling pra imagem)
+"""
+
+MODULE_NAME = "audio_inbound"
+
+MODULE_PROMPT = """## Transcrição de áudio inbound (extensão de mídia)
+
+Quando o passo anterior identificou ``media_type=audio`` (via
+``register_inbound_media`` do módulo "Recepção de mídia"), você PODE
+tentar transcrição via ``analyze_inbound_audio``. Decisão sobre chamá-la
+ou não segue a árvore abaixo.
+
+### Decisão: chamar ``analyze_inbound_audio`` ou pular?
+
+**Chamar somente se TODAS as 2 condições forem verdadeiras:**
+
+(a) A tool ``analyze_inbound_audio`` está disponível no seu toolset
+    (opt-in via ``ENABLE_AUDIO_ADDENDUM=true`` no MCP — se a tool não
+    estiver listada, ela não está disponível).
+
+(b) Você tem ao menos UMA destas fontes de bytes do áudio
+    (em ordem de preferência):
+
+    - ``salesforce_download_path`` no JSON do prefix ``[INBOUND_MEDIA]``
+      (campo ``media.download_path``). **Caminho preferido em produção**
+      — a tool autentica via OAuth Client Credentials e baixa direto do
+      Salesforce REST API, sem truncation de strings longas em tool args.
+    - ``audio_bytes_base64`` no contexto da mensagem (raro em produção
+      porque o LLM trunca strings >~10KB em tool args; útil só pra
+      testes manuais).
+    - ``local_audio_path`` no JSON do prefix (modo teste local com
+      upload manual em ``/tmp``, ``IS_LOCAL=true``).
+
+**Se qualquer condição falhar, NÃO chame a tool.** Volte inteiramente
+ao protocolo do módulo "Recepção de mídia" — ele já trata corretamente
+a distinção entre placeholder (use ``suggested_reply_pt_br`` do
+``register_inbound_media``) vs ``user_text`` real (use o ``user_text``
+como mensagem do cidadão, sem pedir pra ele repetir). Não há regressão
+nesse caminho. **Especificamente: se ``user_text`` veio com transcrição
+real upstream, NÃO chame ``analyze_inbound_audio`` nem peça pro cidadão
+repetir** — siga a partir do ``user_text``.
+
+> Em produção, **sempre passe ``salesforce_download_path``** quando ele
+> estiver presente no prefix ``[INBOUND_MEDIA]``. A tool baixa bytes via
+> SF REST sem você precisar copiar string longa via args.
+
+### Quando AS DUAS condições passam, executar transcrição
+
+1. **Chamar ``analyze_inbound_audio``** logo após o
+   ``register_inbound_media``:
+
+   - ``user_number``: mesmo valor extraído do prefix ``[INBOUND_MEDIA]``
+   - ``file_extension``: do campo ``media.file_extension``. **Allowlist
+     do Gemini audio input (espelhado pela tool):** ``oga``/``ogg``
+     (PTT WhatsApp, container OGG-Opus), ``aac``, ``mp3``, ``wav``,
+     ``flac``, ``aiff``/``aif``. **Não passa**: ``m4a`` (MP4 audio),
+     ``amr`` (codec deprecado), nem outras extensões — a tool rejeita
+     antes de chamar Gemini. Se ``media.file_extension`` cair fora do
+     allowlist, **não chame a tool** e volte ao protocolo do módulo
+     "Recepção de mídia" (mesmo principio do fallback "tool indisponível").
+   - ``message_id``: do prefix se disponível (audit cross-ref)
+   - ``content_version_id``: do campo ``media.content_version_id``
+   - **PREFIRA** ``salesforce_download_path`` (do campo
+     ``media.download_path``) — tool faz download via SF REST sozinha.
+   - Fallbacks: ``audio_bytes_base64`` ou ``local_audio_path`` se o
+     campo ``download_path`` não estiver presente.
+
+2. **Usar a resposta da transcrição.** Retorno contém ``analysis`` com:
+
+   - ``transcricao``: o que o cidadão falou (literal, PT-BR)
+   - ``resumo``: 1-2 frases resumindo o pedido
+   - ``idioma_detectado``: ``pt-br``/``pt-pt``/``es``/``en``/``outro``
+   - ``intencao_detectada``: bool
+   - ``categoria``: ``luminaria_publica``/``poda_arvore``/``buraco_via``/
+     ``endereco``/``duvida_geral``/etc.
+   - ``endereco_mencionado``: endereço ou trecho identificado, ou ``""``
+   - ``workflow_sugerido``: ``reparo_luminaria``/``poda_de_arvore``/``nenhum``
+   - ``confianca``: ``alta``/``media``/``baixa``
+
+   E ``suggested_reply_pt_br`` baseado na análise. Use **esse**
+   ``suggested_reply_pt_br`` como base — NÃO o do
+   ``register_inbound_media`` (que é genérico).
+
+   **Trate ``analysis.transcricao`` como mensagem real do cidadão.**
+   Mesmo princípio do ``user_text`` real do módulo "Recepção de mídia":
+   não peça pra o cidadão repetir o que já falou em áudio.
+
+3. **Iniciar workflow se aplicável.** Se ``analysis.workflow_sugerido``
+   for ``reparo_luminaria`` ou ``poda_de_arvore`` E a ``confianca`` for
+   ``alta`` ou ``media``:
+
+   - Confirme com o cidadão o entendimento ("Ouvi que você está
+     reportando luminária queimada na Rua das Laranjeiras — confirma?").
+   - Se ``analysis.endereco_mencionado`` foi preenchido, **chame
+     ``validate_address`` direto com esse endereço** em vez de pedir o
+     endereço de novo (atalho importante — cidadão acabou de falar).
+   - Após confirmação, inicie via ``multi_step_service`` com o
+     ``service_name`` correspondente.
+
+4. **Fallback se transcrição falha ou é inconclusiva.** Se a tool
+   retornar erro, ``intencao_detectada=false``, ou ``confianca=baixa``,
+   peça ao cidadão pra repetir em texto. Não invente conteúdo que a
+   transcrição não revelou.
+
+### Exemplo de fluxo (áudio sobre luminária queimada)
+
+Entrada do cidadão:
+
+```
+[INBOUND_MEDIA] type=audio user_number=5521989091014 media={"content_version_id":"068xx00000Bgd3T","file_extension":"oga","file_size_bytes":14509,"download_path":"/services/data/v62.0/sobjects/ContentVersion/068xx00000Bgd3T/VersionData"} | user_text=[Cidadao enviou uma mensagem de voz...]
+```
+
+Após ``register_inbound_media``, chame:
+
+```
+analyze_inbound_audio(
+    user_number="5521989091014",
+    file_extension="oga",
+    content_version_id="068xx00000Bgd3T",
+    salesforce_download_path="/services/data/v62.0/sobjects/ContentVersion/068xx00000Bgd3T/VersionData",
+)
+```
+
+Retorno típico:
+
+```json
+{
+  "status": "transcribed",
+  "analysis": {
+    "transcricao": "tem uma luminária queimada na rua das laranjeiras",
+    "resumo": "Reporte de luminária queimada na Rua das Laranjeiras",
+    "idioma_detectado": "pt-br",
+    "intencao_detectada": true,
+    "categoria": "luminaria_publica",
+    "endereco_mencionado": "rua das laranjeiras",
+    "workflow_sugerido": "reparo_luminaria",
+    "confianca": "alta"
+  },
+  "suggested_reply_pt_br": "Ouvi seu áudio: reporte de luminária queimada na Rua das Laranjeiras. Vou te ajudar a abrir um chamado de reparo de luminária — você confirma que quer prosseguir? Me passa o endereço (rua, número, bairro)."
+}
+```
+
+Sua resposta ao cidadão:
+
+> Entendi pelo áudio: luminária queimada na Rua das Laranjeiras.
+> Posso abrir o chamado de reparo. Pra confirmar, me passa o número
+> e o bairro completo?
+
+Se o cidadão responder "150, Laranjeiras", chame direto
+``validate_address(address="Rua das Laranjeiras 150, Laranjeiras")``
+sem pedir o nome da rua de novo — ele já disse no áudio.
+"""

--- a/src/prompt_modules/media_inbound.py
+++ b/src/prompt_modules/media_inbound.py
@@ -68,7 +68,12 @@ Quando a entrada do cidadão começar com `[INBOUND_MEDIA]`, **NÃO** trate como
    - **Se `user_text` é placeholder ou vazio** (vazio/whitespace, ou começa com `[Cidadao enviou ` / `[Cidadão enviou ` / `[INBOUND_MEDIA`): use o campo `suggested_reply_pt_br` retornado pela tool como base — ele já tem mensagem amigável + chamada-para-ação. Adapte o tom ao contexto da conversa.
    - **Se `user_text` é conteúdo real do cidadão** (caption de imagem ou transcrição de áudio): **NÃO** peça pra repetir a informação. Continue o atendimento normalmente usando o `user_text` como parte da mensagem do cidadão; o registro da mídia via tool fica só como audit. Pode mencionar brevemente que recebeu o anexo, mas não bloqueie o fluxo.
 
-4. **Não tente analisar a imagem/áudio.** A tool `register_inbound_media` é stub de recepção (apenas registra audit + retorna sugestão). Processamento de imagem usa a tool separada `analyze_inbound_image` (quando disponível, conforme módulo `vision_inbound`). Transcrição de áudio será adicionada em fases posteriores — não invente capacidade que ainda não existe.
+4. **Use as tools de análise quando aplicável.** A tool `register_inbound_media` é stub de recepção (apenas registra audit + retorna sugestão). Para análise real:
+   - **Imagem:** chame `analyze_inbound_image` em seguida, quando disponível (conforme módulo `vision_inbound` deste prompt).
+   - **Áudio:** chame `analyze_inbound_audio` em seguida, quando disponível (conforme módulo `audio_inbound` deste prompt) — a tool transcreve a fala e retorna intenção + workflow sugerido.
+   - **Localização:** ainda não tem caminho de processamento direto — siga o protocolo de geocoding via texto descrito mais abaixo (caso `media_type=unsupported`).
+
+   Quando o módulo correspondente (`vision_inbound`/`audio_inbound`) estiver presente neste prompt e a tool estiver listada, use-os. Quando o módulo NÃO estiver presente OU a tool NÃO estiver listada, mantenha o fallback genérico do `register_inbound_media` (mensagem amigável pedindo texto).
 
 ### Caso especial: `media_type=unsupported` (geocoding via texto)
 

--- a/tests/unit/test_prompt_modules.py
+++ b/tests/unit/test_prompt_modules.py
@@ -9,7 +9,7 @@ tests pós-deploy em staging.
 """
 
 from src.prompt_modules import compose, ENABLED_MODULES
-from src.prompt_modules import media_inbound, vision_inbound
+from src.prompt_modules import audio_inbound, media_inbound, vision_inbound
 
 
 # ---------- compose() — comportamento básico ----------
@@ -247,6 +247,100 @@ def test_vision_inbound_workflow_suggestions_in_prompt():
     p = vision_inbound.MODULE_PROMPT
     for workflow in ["reparo_luminaria", "poda_de_arvore"]:
         assert workflow in p, f"workflow '{workflow}' não documentado"
+
+
+# ---------- módulo audio_inbound ----------
+
+
+def test_audio_inbound_module_has_required_attributes():
+    """audio_inbound deve seguir o mesmo contrato dos outros módulos."""
+    assert hasattr(audio_inbound, "MODULE_NAME")
+    assert hasattr(audio_inbound, "MODULE_PROMPT")
+    assert isinstance(audio_inbound.MODULE_NAME, str)
+    assert isinstance(audio_inbound.MODULE_PROMPT, str)
+
+
+def test_audio_inbound_module_name_is_stable():
+    """MODULE_NAME do audio_inbound vira sufixo no version (e em logs OTel)."""
+    assert audio_inbound.MODULE_NAME == "audio_inbound"
+
+
+def test_audio_inbound_prompt_mentions_analyze_tool():
+    """Sanity: prompt deve nomear a tool MCP `analyze_inbound_audio` que
+    deve ser chamada — sem isso, o LLM não sabe o nome exato."""
+    p = audio_inbound.MODULE_PROMPT
+    assert "analyze_inbound_audio" in p, "Nome da tool MCP de audio ausente"
+    assert "register_inbound_media" in p, "Referência à tool antecedente ausente"
+
+
+def test_audio_inbound_prompt_handles_opt_in_fallback():
+    """Tool é opt-in (ENABLE_AUDIO_ADDENDUM=true no MCP). Quando não
+    registrada, LLM nem vê o nome. Mas o prompt precisa instruir o
+    fallback explícito pra esse caso."""
+    p = audio_inbound.MODULE_PROMPT.lower()
+    assert "indisponível" in p or "indisponivel" in p or "disponível" in p, (
+        "Falta instrução sobre comportamento quando tool não está registrada"
+    )
+
+
+def test_audio_inbound_prompt_documents_byte_sources():
+    """analyze_inbound_audio aceita salesforce_download_path (prod),
+    audio_bytes_base64 (teste) ou local_audio_path (sandbox). Prompt
+    precisa documentar os 3 pra o LLM saber qual usar."""
+    p = audio_inbound.MODULE_PROMPT
+    assert "salesforce_download_path" in p, "Path do SF não documentado"
+    assert "audio_bytes_base64" in p, "Bytes em base64 não documentados"
+    assert "local_audio_path" in p, "Path local não documentado"
+
+
+def test_audio_inbound_prompt_lists_accepted_extensions():
+    """O cidadão pode enviar PTT (.oga) ou áudios do menu (.m4a, .mp3 etc.).
+    Prompt deve documentar as extensões aceitas pra orientar o LLM."""
+    p = audio_inbound.MODULE_PROMPT
+    assert "oga" in p, "Extensão PTT WhatsApp (.oga) não documentada"
+    # Outras extensões aceitas pela tool — pelo menos uma delas no prompt
+    assert any(ext in p for ext in ["m4a", "mp3", "aac", "wav"]), (
+        "Nenhuma extensão alternativa de audio documentada"
+    )
+
+
+def test_audio_module_appears_after_media_module_in_enabled():
+    """audio_inbound depende semanticamente de media_inbound — a ordem das
+    instruções no prompt importa pro LLM resolver "qual reply usar"
+    (audio suggested_reply substitui o do register stub)."""
+    names = [m.MODULE_NAME for m in ENABLED_MODULES]
+    assert "media_inbound" in names
+    assert "audio_inbound" in names
+    assert names.index("media_inbound") < names.index("audio_inbound"), (
+        "audio_inbound deve vir DEPOIS de media_inbound em ENABLED_MODULES"
+    )
+
+
+def test_audio_inbound_workflow_suggestions_in_prompt():
+    """Os workflows que a transcrição pode sugerir devem estar documentados
+    no prompt pra o LLM saber qual chamar via `multi_step_service`."""
+    p = audio_inbound.MODULE_PROMPT
+    for workflow in ["reparo_luminaria", "poda_de_arvore"]:
+        assert workflow in p, f"workflow '{workflow}' não documentado"
+
+
+def test_audio_inbound_prompt_instructs_not_to_ask_repeat():
+    """analysis.transcricao é mensagem real do cidadão — LLM não deve pedir
+    pra repetir em texto. Sem essa instrução, o LLM joga fora a transcrição
+    e força fricção desnecessária ('manda em texto pra eu te ajudar')."""
+    p = audio_inbound.MODULE_PROMPT.lower()
+    assert "não peça" in p or "nao peça" in p or "não pedir" in p, (
+        "Falta instrução pra não pedir repetição da transcrição"
+    )
+
+
+def test_audio_inbound_prompt_short_circuits_address_when_available():
+    """Se analysis.endereco_mencionado vier preenchido, prompt orienta a
+    chamar validate_address direto em vez de pedir o endereço de novo —
+    atalho importante de UX."""
+    p = audio_inbound.MODULE_PROMPT
+    assert "validate_address" in p, "Atalho via validate_address não documentado"
+    assert "endereco_mencionado" in p, "Field do atalho não referenciado"
 
 
 # ---------- regressão: idempotência de chamada ----------


### PR DESCRIPTION
## Summary

Habilita transcrição de áudio inbound via novo prompt module `audio_inbound`, parelho com `vision_inbound`. Tool MCP correspondente: `analyze_inbound_audio` em [app-mcp-server#60](https://github.com/prefeitura-rio/app-mcp-server/pull/60).

## Mudanças

- **`src/prompt_modules/audio_inbound.py`** (novo): instrui LLM a chamar `analyze_inbound_audio` depois de `register_inbound_media` quando `media_type=audio`. Espelha vision_inbound. Documenta allowlist Gemini alinhado com a tool (oga/ogg/aac/mp3/wav/flac/aiff), atalho via `validate_address` quando `endereco_mencionado` vem preenchido, e fallback explícito pra tool ausente OU file_extension fora do allowlist.
- **`src/prompt_modules/__init__.py`**: registra `audio_inbound` em `ENABLED_MODULES` (depois de vision_inbound, antes de qualquer módulo futuro).
- **`src/prompt_modules/media_inbound.py`**: atualiza seção 4 pra dispatchar pra vision/audio_inbound em vez de "transcrição será adicionada em fases posteriores" — instrução stale que contradizia o novo módulo (P2 do codex).
- **`tests/unit/test_prompt_modules.py`**: 10 testes novos cobrindo audio_inbound (contract, allowlist, opt-in fallback, byte sources, workflow suggestions, no-repeat instruction, validate_address shortcut, ordering).

## Codex review (3 P2s endereçados)

- Preserve real user_text on audio fallback
- Align audio extension list with the tool (m4a/amr fora)
- Remove stale no-audio instruction when enabling audio (em media_inbound)

Última passada veio limpa.

## Test plan

- [x] `uv run pytest tests/unit/test_prompt_modules.py` — 35/35 passed
- [x] `codex review --uncommitted` — clean
- [ ] Deploy Engine novo REASONING_ENGINE_ID
- [ ] E2E manual: cidadão envia áudio "luminária queimada na rua das laranjeiras" → bot transcreve via Gemini + sugere reparo_luminaria no endereço (sem pedir pra repetir em texto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)