### PR TITLE
feat(prompt-modules): ensina LLM a usar meta_media_id (ADR-017)

### DIFF
--- a/src/prompt_modules/audio_inbound.py
+++ b/src/prompt_modules/audio_inbound.py
@@ -42,10 +42,16 @@ ou não segue a árvore abaixo.
 (b) Você tem ao menos UMA destas fontes de bytes do áudio
     (em ordem de preferência):
 
+    - ``meta_media_id`` no JSON do prefix ``[INBOUND_MEDIA]`` (campo
+      ``media.meta_media_id``). **Caminho canônico atual em produção
+      (ADR-017)** — cidadão veio via Meta webhook direto pro Mule.
+      A tool faz 2 GETs no Graph API (metadata + signed CDN URL) com
+      ``WA_TOKEN``. Handle automaticamente ``audio/ogg; codecs=opus``
+      (PTT WhatsApp).
     - ``salesforce_download_path`` no JSON do prefix ``[INBOUND_MEDIA]``
-      (campo ``media.download_path``). **Caminho preferido em produção**
-      — a tool autentica via OAuth Client Credentials e baixa direto do
-      Salesforce REST API, sem truncation de strings longas em tool args.
+      (campo ``media.download_path``). Caminho UWC legacy — cidadão veio
+      via Salesforce UWC. A tool autentica via OAuth Client Credentials
+      e baixa direto do Salesforce REST API.
     - ``audio_bytes_base64`` no contexto da mensagem (raro em produção
       porque o LLM trunca strings >~10KB em tool args; útil só pra
       testes manuais).
@@ -71,20 +77,33 @@ repetir** — siga a partir do ``user_text``.
    ``register_inbound_media``:
 
    - ``user_number``: mesmo valor extraído do prefix ``[INBOUND_MEDIA]``
-   - ``file_extension``: do campo ``media.file_extension``. **Allowlist
-     do Gemini audio input (espelhado pela tool):** ``oga``/``ogg``
-     (PTT WhatsApp, container OGG-Opus), ``aac``, ``mp3``, ``wav``,
-     ``flac``, ``aiff``/``aif``. **Não passa**: ``m4a`` (MP4 audio),
-     ``amr`` (codec deprecado), nem outras extensões — a tool rejeita
-     antes de chamar Gemini. Se ``media.file_extension`` cair fora do
-     allowlist, **não chame a tool** e volte ao protocolo do módulo
-     "Recepção de mídia" (mesmo principio do fallback "tool indisponível").
    - ``message_id``: do prefix se disponível (audit cross-ref)
-   - ``content_version_id``: do campo ``media.content_version_id``
-   - **PREFIRA** ``salesforce_download_path`` (do campo
-     ``media.download_path``) — tool faz download via SF REST sozinha.
-   - Fallbacks: ``audio_bytes_base64`` ou ``local_audio_path`` se o
-     campo ``download_path`` não estiver presente.
+   - **Caminho A — Meta webhook direto (ADR-017, canal canônico):**
+     quando o JSON ``media`` tem ``meta_media_id`` (cidadão veio via
+     ``/meta/webhook`` no Mule), passe APENAS:
+     - ``meta_media_id``: do campo ``media.meta_media_id``
+     - ``file_extension`` (opcional): a tool deriva do MIME real
+       retornado pelo Graph API (handle ``audio/ogg; codecs=opus`` e
+       outros parametrizados). Pode omitir.
+     Não passe ``content_version_id`` nem ``salesforce_download_path``
+     nesse caminho — não existem no payload Meta direto.
+   - **Caminho B — UWC legacy (Salesforce ContentVersion):** quando o
+     JSON ``media`` tem ``content_version_id``/``download_path`` (sem
+     ``meta_media_id``):
+     - ``file_extension``: do campo ``media.file_extension``.
+       **Allowlist do Gemini audio input (espelhado pela tool):**
+       ``oga``/``ogg`` (PTT WhatsApp, container OGG-Opus), ``aac``,
+       ``mp3``, ``wav``, ``flac``, ``aiff``/``aif``. **Não passa**:
+       ``m4a`` (MP4 audio), ``amr`` (codec deprecado), nem outras
+       extensões — a tool rejeita antes de chamar Gemini. Se
+       ``media.file_extension`` cair fora do allowlist, **não chame a
+       tool** e volte ao protocolo do módulo "Recepção de mídia".
+     - ``content_version_id``: do campo ``media.content_version_id``
+     - **PREFIRA** ``salesforce_download_path`` (do campo
+       ``media.download_path``) — tool faz download via SF REST sozinha.
+     - Fallbacks: ``audio_bytes_base64`` ou ``local_audio_path`` se o
+       campo ``download_path`` não estiver presente.
+   - **Quando ambos presentes:** prefira Caminho A.
 
 2. **Usar a resposta da transcrição.** Retorno contém ``analysis`` com:
 

--- a/src/prompt_modules/media_inbound.py
+++ b/src/prompt_modules/media_inbound.py
@@ -58,7 +58,13 @@ Quando a entrada do cidadão começar com `[INBOUND_MEDIA]`, **NÃO** trate como
    - `media_type`: o valor extraído de `type=`
    - `user_number`: o valor extraído de `user_number=`
    - Para `image`/`audio`/`unknown` (quando `media` tem conteúdo):
-     - `content_version_id`, `file_extension`, `file_size_bytes`, `salesforce_download_path` (do campo `download_path`) — extraídos do JSON `media`
+     - **Caminho A — Meta webhook direto (ADR-017, canal canônico atual):** quando o JSON `media` contém `meta_media_id`, o cidadão veio via `/meta/webhook` no Mule (Meta App não-BSP do Bruno). Passe:
+       - `meta_media_id`: do campo `media.meta_media_id`
+       - `meta_mime_type`: do campo `media.mime_type` (se presente)
+       - Não precisa de `content_version_id` nem `salesforce_download_path` (não vão existir no payload Meta-direto).
+     - **Caminho B — UWC legacy:** quando o JSON `media` contém `content_version_id` + `download_path` (sem `meta_media_id`), o cidadão veio via Salesforce UWC. Passe:
+       - `content_version_id`, `file_extension`, `file_size_bytes`, `salesforce_download_path` (do campo `download_path`)
+     - **Quando ambos presentes:** prefira o Caminho A (Meta direto) — é o canal canônico ativo.
    - Para `location` (quando suporte do canal habilitar lat/lng):
      - `latitude`, `longitude`, `address` — do JSON `media`
    - Para `unsupported`: chame com apenas `media_type` + `user_number`
@@ -154,5 +160,35 @@ Entrada:
 Você ainda chama `register_inbound_media` para audit. Mas o `user_text` é conteúdo real — **não peça pra repetir**. Resposta:
 
 > Anotei o relato (recebi também o áudio). Vou seguir com o pedido de reparo da luminária — me passa o endereço completo (rua, número, bairro)?
+
+### Exemplo Meta webhook direto (Caminho A — canal canônico atual)
+
+Entrada do cidadão (vem do Mule `/meta/webhook`, não tem ContentVersion no SF):
+
+```
+[INBOUND_MEDIA] type=image user_number=5521989091014 media={"meta_media_id":"1234567890123456","mime_type":"image/jpeg"} | user_text=[Cidadao enviou uma imagem...]
+```
+
+Sua chamada de tool:
+
+```
+register_inbound_media(
+    media_type="image",
+    user_number="5521989091014",
+    meta_media_id="1234567890123456",
+    meta_mime_type="image/jpeg",
+)
+```
+
+E em seguida (se módulo `vision_inbound` ativo):
+
+```
+analyze_inbound_image(
+    user_number="5521989091014",
+    meta_media_id="1234567890123456",
+)
+```
+
+`file_extension` é opcional aqui — a tool deriva do MIME real retornado pelo Graph API do Meta.
 
 """

--- a/src/prompt_modules/vision_inbound.py
+++ b/src/prompt_modules/vision_inbound.py
@@ -55,11 +55,15 @@ chamá-la ou não segue a árvore abaixo:
 (b) Você tem ao menos UMA destas fontes de bytes da imagem
     (em ordem de preferência):
 
+    - ``meta_media_id`` no JSON do prefix ``[INBOUND_MEDIA]`` (campo
+      ``media.meta_media_id``). **Caminho canônico atual em produção
+      (ADR-017)** — cidadão veio via Meta webhook direto pro Mule.
+      A tool faz 2 GETs no Graph API (metadata + signed CDN URL) com
+      ``WA_TOKEN``, sem precisar do Salesforce.
     - ``salesforce_download_path`` no JSON do prefix ``[INBOUND_MEDIA]``
-      (campo ``media.download_path``). **Caminho preferido em produção**
-      — a tool autentica via OAuth Client Credentials e baixa direto do
-      Salesforce REST API, sem truncation de strings longas em tool
-      args.
+      (campo ``media.download_path``). Caminho UWC legacy — cidadão veio
+      via Salesforce UWC. A tool autentica via OAuth Client Credentials
+      e baixa direto do Salesforce REST API.
     - ``image_bytes_base64`` no contexto da mensagem (raro em produção
       porque o LLM trunca strings >~10KB em tool args; útil só pra
       testes manuais).
@@ -82,13 +86,26 @@ cidadão, sem pedir pra repetir). Não há regressão nesse caminho.
 1. **Chamar ``analyze_inbound_image``** logo após o ``register_inbound_media``:
 
    - ``user_number``: mesmo valor extraído do prefix ``[INBOUND_MEDIA]``
-   - ``file_extension``: do campo ``media.file_extension``
    - ``message_id``: do prefix se disponível (audit cross-ref)
-   - ``content_version_id``: do campo ``media.content_version_id``
-   - **PREFIRA** ``salesforce_download_path`` (do campo
-     ``media.download_path``) — tool faz download via SF REST sozinha.
-   - Fallbacks: ``image_bytes_base64`` ou ``local_image_path`` se
-     ``salesforce_download_path`` não estiver presente no prefix.
+   - **Caminho A — Meta webhook direto (ADR-017, canal canônico):**
+     quando o JSON ``media`` tem ``meta_media_id`` (cidadão veio via
+     ``/meta/webhook`` no Mule), passe APENAS:
+     - ``meta_media_id``: do campo ``media.meta_media_id``
+     - ``file_extension`` (opcional): a tool deriva do MIME real
+       retornado pelo Graph API. Pode omitir.
+     Não passe ``content_version_id`` nem ``salesforce_download_path``
+     nesse caminho — não existem no payload Meta direto.
+   - **Caminho B — UWC legacy (Salesforce ContentVersion):** quando o
+     JSON ``media`` tem ``content_version_id``/``download_path`` (sem
+     ``meta_media_id``):
+     - ``file_extension``: do campo ``media.file_extension`` (obrigatório
+       aqui)
+     - ``content_version_id``: do campo ``media.content_version_id``
+     - **PREFIRA** ``salesforce_download_path`` (do campo
+       ``media.download_path``) — tool faz download via SF REST sozinha.
+     - Fallbacks: ``image_bytes_base64`` ou ``local_image_path`` se
+       ``salesforce_download_path`` não estiver presente no prefix.
+   - **Quando ambos presentes:** prefira Caminho A.
 
 2. **Usar a resposta da análise.** O retorno contém ``analysis`` com:
 


### PR DESCRIPTION
Fecha o loop do ADR-017 (Meta webhook direto). MCP server (PR #62, mergeada + deploy staging) ja aceita meta_media_id em analyze_inbound_image/audio + register_inbound_media. Esta PR ensina LLM a extrair e passar esse campo quando vier do canal canonico atual.

## Sumario
- media_inbound: instrui register_inbound_media com meta_media_id + meta_mime_type (Caminho A); UWC legacy (content_version_id + download_path) eh Caminho B
- vision_inbound + audio_inbound: gate de fontes de bytes agora inclui meta_media_id como caminho canonico (sem isso LLM stopava em register sem analisar)
- Audio: file_extension agora Optional pra Caminho A (tool deriva do MIME real, handle audio/ogg; codecs=opus)

## Test plan
- [x] tests/unit/test_prompt_modules.py -> 35 passing
- [x] Codex review iterativo (2 P1s endereçados sobre gate de fontes), final pass clean
- [ ] Smoke E2E real apos deploy: cidadao envia foto WhatsApp via Meta direto -> bot responde com analise Gemini Vision

🤖 Generated with Claude Code