### PR TITLE
fix(prompts): instrução imperativa pra Gemini Flash chamar analyze tools

### DIFF
--- a/src/prompt_modules/audio_inbound.py
+++ b/src/prompt_modules/audio_inbound.py
@@ -74,36 +74,26 @@ repetir** — siga a partir do ``user_text``.
 ### Quando AS DUAS condições passam, executar transcrição
 
 1. **Chamar ``analyze_inbound_audio``** logo após o
-   ``register_inbound_media``:
+   ``register_inbound_media``. **OBRIGATÓRIO** — sem isso o cidadão recebe
+   apenas o fallback genérico "não consigo transcrever áudio" do
+   ``register_inbound_media``, que NÃO É a resposta desejada quando há
+   áudio real:
 
    - ``user_number``: mesmo valor extraído do prefix ``[INBOUND_MEDIA]``
-   - ``message_id``: do prefix se disponível (audit cross-ref)
-   - **Caminho A — Meta webhook direto (ADR-017, canal canônico):**
-     quando o JSON ``media`` tem ``meta_media_id`` (cidadão veio via
-     ``/meta/webhook`` no Mule), passe APENAS:
-     - ``meta_media_id``: do campo ``media.meta_media_id``
-     - ``file_extension`` (opcional): a tool deriva do MIME real
-       retornado pelo Graph API (handle ``audio/ogg; codecs=opus`` e
-       outros parametrizados). Pode omitir.
-     Não passe ``content_version_id`` nem ``salesforce_download_path``
-     nesse caminho — não existem no payload Meta direto.
-   - **Caminho B — UWC legacy (Salesforce ContentVersion):** quando o
-     JSON ``media`` tem ``content_version_id``/``download_path`` (sem
-     ``meta_media_id``):
-     - ``file_extension``: do campo ``media.file_extension``.
-       **Allowlist do Gemini audio input (espelhado pela tool):**
-       ``oga``/``ogg`` (PTT WhatsApp, container OGG-Opus), ``aac``,
-       ``mp3``, ``wav``, ``flac``, ``aiff``/``aif``. **Não passa**:
-       ``m4a`` (MP4 audio), ``amr`` (codec deprecado), nem outras
-       extensões — a tool rejeita antes de chamar Gemini. Se
-       ``media.file_extension`` cair fora do allowlist, **não chame a
-       tool** e volte ao protocolo do módulo "Recepção de mídia".
-     - ``content_version_id``: do campo ``media.content_version_id``
-     - **PREFIRA** ``salesforce_download_path`` (do campo
-       ``media.download_path``) — tool faz download via SF REST sozinha.
-     - Fallbacks: ``audio_bytes_base64`` ou ``local_audio_path`` se o
-       campo ``download_path`` não estiver presente.
-   - **Quando ambos presentes:** prefira Caminho A.
+   - ``message_id``: do prefix se disponível
+   - **SE o JSON ``media`` tem ``meta_media_id``** (canal canônico Meta direto):
+     - ``meta_media_id``: o valor (string) do campo ``media.meta_media_id``
+     - Não precisa de ``file_extension`` — tool deriva do MIME real do
+       Graph API (handle ``audio/ogg; codecs=opus`` automático).
+   - **SE o JSON ``media`` tem ``content_version_id``** (UWC legacy):
+     - ``file_extension``: do campo ``media.file_extension`` (**allowlist
+       Gemini**: ``oga``/``ogg``/``aac``/``mp3``/``wav``/``flac``/``aiff``;
+       NÃO ``m4a``/``amr``). Se fora do allowlist, NÃO chame a tool.
+     - ``content_version_id``: ``media.content_version_id``
+     - ``salesforce_download_path``: ``media.download_path``
+   - **SE ambos presentes**: passe ``meta_media_id`` (a tool prioriza esse caminho).
+
+   **REGRA CRÍTICA:** Quando o prefix `[INBOUND_MEDIA] type=audio` chegar, você TEM que chamar `analyze_inbound_audio` ALÉM de `register_inbound_media`. Chamar APENAS `register_inbound_media` resulta em resposta genérica "não consigo ouvir" — isso é regressão.
 
 2. **Usar a resposta da transcrição.** Retorno contém ``analysis`` com:
 

--- a/src/prompt_modules/media_inbound.py
+++ b/src/prompt_modules/media_inbound.py
@@ -53,21 +53,21 @@ Quando a entrada do cidadão começar com `[INBOUND_MEDIA]`, **NÃO** trate como
      - **Considere placeholder/sem-conteúdo-real** quando: (a) string vazia/só whitespace, (b) começa com `[Cidadao enviou ` (sem acento), (c) começa com `[Cidadão enviou ` (com acento), (d) começa com `[INBOUND_MEDIA`. Ignore para fins de raciocínio. (O Mule envia atualmente sem acento; o pattern com acento fica reservado pra evolução futura do gateway.)
      - Caso contrário, trate como mensagem real do cidadão associada à mídia.
 
-2. **Chame imediatamente a tool `register_inbound_media`** com:
+2. **Chame imediatamente a tool `register_inbound_media`** passando TODOS os campos disponíveis no JSON `media`. **OBRIGATÓRIO**:
 
    - `media_type`: o valor extraído de `type=`
    - `user_number`: o valor extraído de `user_number=`
-   - Para `image`/`audio`/`unknown` (quando `media` tem conteúdo):
-     - **Caminho A — Meta webhook direto (ADR-017, canal canônico atual):** quando o JSON `media` contém `meta_media_id`, o cidadão veio via `/meta/webhook` no Mule (Meta App não-BSP do Bruno). Passe:
-       - `meta_media_id`: do campo `media.meta_media_id`
-       - `meta_mime_type`: do campo `media.mime_type` (se presente)
-       - Não precisa de `content_version_id` nem `salesforce_download_path` (não vão existir no payload Meta-direto).
-     - **Caminho B — UWC legacy:** quando o JSON `media` contém `content_version_id` + `download_path` (sem `meta_media_id`), o cidadão veio via Salesforce UWC. Passe:
-       - `content_version_id`, `file_extension`, `file_size_bytes`, `salesforce_download_path` (do campo `download_path`)
-     - **Quando ambos presentes:** prefira o Caminho A (Meta direto) — é o canal canônico ativo.
-   - Para `location` (quando suporte do canal habilitar lat/lng):
-     - `latitude`, `longitude`, `address` — do JSON `media`
-   - Para `unsupported`: chame com apenas `media_type` + `user_number`
+   - **SE o JSON `media` contém `meta_media_id`** (caminho Meta direto, ADR-017):
+     - `meta_media_id`: o valor do campo `media.meta_media_id` (string, ex: `"864820469982533"`)
+     - `meta_mime_type`: o valor do campo `media.mime_type` se presente (ex: `"image/jpeg"`)
+   - **SE o JSON `media` contém `content_version_id`** (caminho UWC legacy):
+     - `content_version_id`, `file_extension`, `file_size_bytes` do JSON
+     - `salesforce_download_path`: do campo `media.download_path`
+   - **SE o JSON `media` contém ambos** (`meta_media_id` E `content_version_id`): passe os dois — tool prioriza `meta_media_id`.
+   - Para `location`: `latitude`, `longitude`, `address` do JSON `media`.
+   - Para `unsupported`: apenas `media_type` + `user_number`.
+
+   **CRITICAL: NÃO chame `register_inbound_media` apenas com `media_type` + `user_number` quando o JSON `media` tem conteúdo. Sempre extraia e passe os campos de identificação da mídia (`meta_media_id` OU `content_version_id`). Sem isso a tool não pode rastrear o arquivo e a análise downstream falha.**
 
 3. **Componha a resposta ao cidadão** levando em conta o conteúdo de `user_text` extraído no passo 1:
 

--- a/src/prompt_modules/vision_inbound.py
+++ b/src/prompt_modules/vision_inbound.py
@@ -83,29 +83,20 @@ cidadão, sem pedir pra repetir). Não há regressão nesse caminho.
 
 ### Quando AS DUAS condições passam, executar análise
 
-1. **Chamar ``analyze_inbound_image``** logo após o ``register_inbound_media``:
+1. **Chamar ``analyze_inbound_image``** logo após o ``register_inbound_media``. **OBRIGATÓRIO** — sem isso o cidadão recebe apenas o fallback genérico "não consigo analisar fotos" do `register_inbound_media`, que NÃO É a resposta desejada quando há foto real:
 
    - ``user_number``: mesmo valor extraído do prefix ``[INBOUND_MEDIA]``
    - ``message_id``: do prefix se disponível (audit cross-ref)
-   - **Caminho A — Meta webhook direto (ADR-017, canal canônico):**
-     quando o JSON ``media`` tem ``meta_media_id`` (cidadão veio via
-     ``/meta/webhook`` no Mule), passe APENAS:
-     - ``meta_media_id``: do campo ``media.meta_media_id``
-     - ``file_extension`` (opcional): a tool deriva do MIME real
-       retornado pelo Graph API. Pode omitir.
-     Não passe ``content_version_id`` nem ``salesforce_download_path``
-     nesse caminho — não existem no payload Meta direto.
-   - **Caminho B — UWC legacy (Salesforce ContentVersion):** quando o
-     JSON ``media`` tem ``content_version_id``/``download_path`` (sem
-     ``meta_media_id``):
-     - ``file_extension``: do campo ``media.file_extension`` (obrigatório
-       aqui)
-     - ``content_version_id``: do campo ``media.content_version_id``
-     - **PREFIRA** ``salesforce_download_path`` (do campo
-       ``media.download_path``) — tool faz download via SF REST sozinha.
-     - Fallbacks: ``image_bytes_base64`` ou ``local_image_path`` se
-       ``salesforce_download_path`` não estiver presente no prefix.
-   - **Quando ambos presentes:** prefira Caminho A.
+   - **SE o JSON ``media`` tem ``meta_media_id``** (canal canônico Meta direto, ADR-017):
+     - ``meta_media_id``: o valor (string) do campo ``media.meta_media_id``
+     - Não precisa de ``file_extension`` (tool deriva do MIME real do Graph API)
+   - **SE o JSON ``media`` tem ``content_version_id``** (UWC legacy):
+     - ``content_version_id``: ``media.content_version_id``
+     - ``file_extension``: ``media.file_extension``
+     - ``salesforce_download_path``: ``media.download_path``
+   - **SE ambos presentes**: passe ``meta_media_id`` (a tool prioriza esse caminho).
+
+   **REGRA CRÍTICA:** Quando o prefix `[INBOUND_MEDIA] type=image` chegar, você TEM que chamar `analyze_inbound_image` ALÉM de `register_inbound_media`. Chamar APENAS `register_inbound_media` resulta em resposta genérica "não consigo analisar fotos" — isso é regressão, não comportamento esperado.
 
 2. **Usar a resposta da análise.** O retorno contém ``analysis`` com:
 


### PR DESCRIPTION
Smoke E2E real com cidadão revelou Gemini 2.5 Flash ignorando instrucao do Caminho A. Logs mostram prefix com meta_media_id correto mas LLM chamou register_inbound_media APENAS com media_type+user_number, sem analyze_inbound_image. Resposta = fallback genérico stub.

Reformulação: estrutura Caminho A/B substituida por SE-presente-passe-X. Marca chamar analyze como OBRIGATORIO. CRITICAL note dizendo regressao se nao chamar.

Tests 35/35 passing.