### PR TITLE
refactor(prompt-modules): DRY via AnalyzableMediaSpec template (ADR-018)

### DIFF
--- a/src/prompt_modules/_analyzable_media_template.py
+++ b/src/prompt_modules/_analyzable_media_template.py
@@ -1,0 +1,221 @@
+"""
+Template generator pra módulos de prompt de mídia analisável.
+
+Atualmente reusado por `vision_inbound` (imagens) e `audio_inbound` (áudios).
+Adicionar suporte futuro a vídeo (ou outro tipo analisável via Gemini multimodal)
+vira: criar nova `AnalyzableMediaSpec` + arquivo `<tipo>_inbound.py` que chama
+`render_module_prompt(spec)`.
+
+Por que template-driven em vez de copy-paste:
+- Garante que mudanças de protocolo (ex: novo arg `meta_mime_type`, nova
+  prioridade de fonte) propaguem pra todos os tipos simultaneamente.
+- Mantém wording-sensitive sections (regras de classificação) específicas de
+  cada tipo no próprio arquivo, evitando sobre-abstração.
+
+Por que NÃO um único arquivo "media_analysis_module.py" gerando tudo:
+- Cada arquivo de tipo (vision_inbound, audio_inbound) carrega a sua
+  `MODULE_NAME` única — exigida pelo composer (`prompt_modules/__init__.py`)
+  pra entrar no version suffix observável (`v179+media_inbound+vision_inbound`).
+- Permite ENABLED_MODULES desligar um tipo sem afetar outro.
+
+ADR-018, 2026-05-14 noite.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+
+@dataclass(frozen=True)
+class AnalyzableMediaSpec:
+    """Configuração imutável por tipo de mídia analisável.
+
+    Cada `<tipo>_inbound.py` cria uma instância e chama `render_module_prompt`.
+    """
+
+    # Identificador único — vira `MODULE_NAME` (aparece no version suffix).
+    module_name: str
+    # Tipo no prefix do gateway (`[INBOUND_MEDIA] type=<media_type>`).
+    media_type: str
+    # Nome da tool MCP correspondente.
+    analyze_tool: str
+    # Domínio textual usado em frases ("imagem"/"foto" vs "áudio"/"voz").
+    domain_noun_singular: str  # "imagem", "áudio"
+    domain_noun_indefinite: str  # "uma imagem", "um áudio"
+    domain_action: str  # "analisar" (image) vs "ouvir/transcrever" (audio)
+    domain_action_present: str  # "análise" vs "transcrição"
+    # Allowlist de extensions aceitas pela tool (afeta o gate decision).
+    accepted_extensions: Sequence[str]
+    # Extensions NÃO aceitas mas conhecidas (mencionadas pra LLM saber rejeitar).
+    rejected_extensions_note: Optional[str] = None
+    # Nome do arg de bytes inline (`image_bytes_base64` vs `audio_bytes_base64`).
+    # Test contract exige esse nome literal no prompt.
+    bytes_base64_arg_name: str = "bytes_base64"
+    # Nome do arg de caminho local (`local_image_path` vs `local_audio_path`).
+    local_path_arg_name: str = "local_path"
+    # Env var que controla o opt-in da tool no MCP. NÃO derivável de
+    # media_type — vision usa ENABLE_VISION_ADDENDUM, audio usa
+    # ENABLE_AUDIO_ADDENDUM (e não ENABLE_IMAGE_*/ENABLE_AUDIO_*). Quando
+    # adicionar tipo novo, defina aqui pra bater com o flag real no MCP.
+    enable_env_var: str = "ENABLE_MEDIA_ADDENDUM"
+    # Se `True`, prompt instrui pular `{analyze_tool}` quando `user_text`
+    # vier com conteúdo real (caption/transcription upstream). Adequado pra
+    # áudio (transcription real torna análise redundante) mas NÃO pra
+    # imagem (caption não substitui análise visual).
+    skip_analyze_on_real_user_text: bool = False
+    # Seção markdown adicional após "Quando AS DUAS condições passam".
+    # Contém o schema do JSON de análise + regras de interpretação.
+    type_specific_guidance: str = ""
+    # Exemplo de chamada Meta direto (mostra como passar args).
+    example_meta_direct_call: str = ""
+    # Exemplo de chamada Salesforce UWC (legacy fallback).
+    example_uwc_call: str = ""
+
+
+# ----------------------------------------------------------------------------
+# Renderers de seções
+# ----------------------------------------------------------------------------
+
+
+def _render_header(spec: AnalyzableMediaSpec) -> str:
+    return f"## Análise de {spec.domain_noun_singular} inbound (`{spec.analyze_tool}`)"
+
+
+def _render_opt_in_gate(spec: AnalyzableMediaSpec) -> str:
+    return f"""\
+### Decisão: chamar `{spec.analyze_tool}` ou pular?
+
+Chamar a tool **somente quando AS DUAS** condições abaixo passarem:
+
+(a) A tool `{spec.analyze_tool}` está disponível no seu toolset
+    (opt-in via `{spec.enable_env_var}=true` no MCP — se a tool
+    não estiver listada, ela não está disponível).
+
+(b) Você tem ao menos UMA destas fontes de bytes do {spec.domain_noun_singular}
+    (em ordem de preferência):
+
+    - `meta_media_id` no JSON do prefix `[INBOUND_MEDIA]` (campo
+      `media.meta_media_id`). **Caminho canônico atual em produção
+      (ADR-017)** — cidadão veio via Meta webhook direto pro Mule.
+      A tool faz 2 GETs no Graph API (metadata + signed CDN URL) com
+      `WA_TOKEN`.
+    - `salesforce_download_path` no JSON do prefix `[INBOUND_MEDIA]`
+      (campo `media.download_path`). Caminho UWC legacy — cidadão veio
+      via Salesforce UWC. A tool autentica via OAuth Client Credentials
+      e baixa direto do Salesforce REST API.
+    - `{spec.bytes_base64_arg_name}` no contexto (raro em produção; LLM trunca >~10KB;
+      útil só pra testes manuais).
+    - `{spec.local_path_arg_name}` no JSON do prefix (sandbox `/tmp` com `IS_LOCAL=true`).
+
+**Se qualquer uma das 2 condições falhar, NÃO chame a tool.** Volte
+inteiramente ao protocolo do módulo "Recepção de mídia" — ele já trata
+corretamente a distinção entre placeholder (use `suggested_reply_pt_br`
+do registro) vs `user_text` real (use o `user_text` como mensagem do
+cidadão, sem pedir pra ele repetir).
+
+> Em produção, **sempre passe `meta_media_id` ou `salesforce_download_path`**
+> quando ele estiver presente no prefix `[INBOUND_MEDIA]`. A tool baixa
+> bytes sem você precisar copiar string longa via args (que o modelo
+> tende a truncar).
+"""
+
+
+def _render_skip_exception(spec: AnalyzableMediaSpec) -> str:
+    """Renderiza a exceção "pular analyze se user_text é real" — APENAS pra
+    tipos onde user_text upstream substitui o sinal da análise (ex: audio
+    com transcrição já feita). Imagem NÃO entra aqui porque caption ≠
+    visualização. Codex review 2026-05-15."""
+    if not spec.skip_analyze_on_real_user_text:
+        return ""
+    return f"""
+
+   **EXCEÇÃO — `user_text` real ({spec.domain_noun_singular}):** se `user_text`
+   no prefix NÃO é placeholder (vazio/`[Cidadao enviou `/`[Cidadão enviou `/
+   `[INBOUND_MEDIA`) e tem conteúdo significativo (transcrição upstream do
+   {spec.domain_noun_singular}), o cidadão já forneceu a informação por texto —
+   `register` suficiente. **Não force `{spec.analyze_tool}` nesse caso**, use o
+   `user_text` como a mensagem real e siga o fluxo. Evita chamada Gemini
+   desnecessária."""
+
+
+def _render_call_section(spec: AnalyzableMediaSpec) -> str:
+    ext_note = (
+        f"\n     **Allowlist Gemini**: {', '.join(f'`{e}`' for e in spec.accepted_extensions)}."
+        if spec.accepted_extensions
+        else ""
+    )
+    rejected = (
+        f"\n     {spec.rejected_extensions_note}"
+        if spec.rejected_extensions_note
+        else ""
+    )
+    return f"""\
+### Quando AS DUAS condições passam, executar análise
+
+1. **Chamar `{spec.analyze_tool}`** logo após o `register_inbound_media`.
+   **OBRIGATÓRIO** — sem isso o cidadão recebe apenas o fallback genérico
+   do `register_inbound_media`, que NÃO É a resposta desejada quando há
+   {spec.domain_noun_indefinite} real:
+
+   - `user_number`: mesmo valor extraído do prefix `[INBOUND_MEDIA]`
+   - `message_id`: do prefix se disponível
+   - **SE o JSON `media` tem `meta_media_id`** (canal canônico Meta direto, ADR-017):
+     - `meta_media_id`: o valor (string) do campo `media.meta_media_id`
+     - Não precisa de `file_extension` — tool deriva do MIME real do
+       Graph API.
+   - **SE o JSON `media` tem `content_version_id`** (UWC legacy):
+     - `content_version_id`: `media.content_version_id`
+     - `file_extension`: `media.file_extension`{ext_note}{rejected}
+     - `salesforce_download_path`: `media.download_path`
+   - **SE ambos presentes**: passe `meta_media_id` (a tool prioriza esse caminho).
+
+   **REGRA CRÍTICA:** Quando o prefix `[INBOUND_MEDIA] type={spec.media_type}`
+   chegar, você TEM que chamar `{spec.analyze_tool}` ALÉM de
+   `register_inbound_media`. Chamar APENAS `register_inbound_media` resulta
+   em resposta genérica — isso é regressão.{_render_skip_exception(spec)}
+
+2. **Usar a resposta da {spec.domain_action_present}.** O retorno contém
+   `analysis` com os campos específicos do tipo (ver schema abaixo) +
+   `suggested_reply_pt_br` baseado na análise. Use **esse**
+   `suggested_reply_pt_br` (da análise) como base da resposta ao cidadão —
+   NÃO o do `register_inbound_media`, que é genérico.
+
+3. **Iniciar workflow se aplicável** com base em `analysis.workflow_sugerido`
+   e `analysis.confianca` (ver type_specific_guidance abaixo).
+
+4. **Fallback se análise falha ou é inconclusiva.** Se a tool retornar erro,
+   `problema_detectado=false`/`intencao_detectada=false` com
+   `categoria=nao_aplica`, ou `confianca=baixa`, **volte ao protocolo do
+   módulo "Recepção de mídia"**.
+"""
+
+
+def _render_examples(spec: AnalyzableMediaSpec) -> str:
+    if not (spec.example_meta_direct_call or spec.example_uwc_call):
+        return ""
+    parts = ["### Exemplos de chamada"]
+    if spec.example_meta_direct_call:
+        parts.append(f"**Meta webhook direto (canal canônico):**\n```\n{spec.example_meta_direct_call}\n```")
+    if spec.example_uwc_call:
+        parts.append(f"**UWC legacy (Salesforce ContentVersion):**\n```\n{spec.example_uwc_call}\n```")
+    return "\n\n".join(parts)
+
+
+def render_module_prompt(spec: AnalyzableMediaSpec) -> str:
+    """Renderiza o `MODULE_PROMPT` completo a partir da spec.
+
+    Junta header + opt-in gate + call section + type-specific guidance +
+    examples na ordem que o LLM espera ler.
+    """
+    sections = [
+        _render_header(spec),
+        _render_opt_in_gate(spec),
+        _render_call_section(spec),
+    ]
+    if spec.type_specific_guidance:
+        sections.append(spec.type_specific_guidance.rstrip())
+    examples = _render_examples(spec)
+    if examples:
+        sections.append(examples)
+    return "\n\n".join(s.rstrip() for s in sections) + "\n"

--- a/src/prompt_modules/audio_inbound.py
+++ b/src/prompt_modules/audio_inbound.py
@@ -1,182 +1,128 @@
 """
 Módulo de prompt: instruções para o LLM chamar a tool MCP
 ``analyze_inbound_audio`` (Gemini multimodal) depois de
-``register_inbound_media`` quando o cidadão envia áudio via WhatsApp.
+``register_inbound_media`` quando o cidadão envia áudio real pelo WhatsApp.
 
-Contexto:
+Contexto upstream (resumido):
 
-* :mod:`src.prompt_modules.media_inbound` já instrui o LLM a chamar
-  ``register_inbound_media`` (stub de recepção/audit) quando vê o prefix
-  ``[INBOUND_MEDIA]``. Esse stub registra mas não transcreve.
+* O módulo ``media_inbound`` já documenta o protocolo do prefix
+  ``[INBOUND_MEDIA]`` e instrui o LLM a chamar ``register_inbound_media``
+  (stub de recepção).
 * A tool MCP ``analyze_inbound_audio`` (em
-  ``prefeitura-rio/app-mcp-server``, arquivo
-  ``src/tools/inbound_media_audio.py``) faz transcrição real via Gemini
-  multimodal e classifica em workflows (``reparo_luminaria``,
-  ``poda_de_arvore``, ``nenhum``). É **opt-in** no MCP via flag
-  ``ENABLE_AUDIO_ADDENDUM=true`` (default-on) — sem o flag a tool não é
-  registrada e o LLM nem a vê (instruções abaixo viram no-op).
+  ``prefeitura-rio/app-mcp-server/src/tools/inbound_media_audio.py``)
+  estende o stub: baixa via Meta CDN ou Salesforce REST, transcreve via
+  Gemini multimodal, retorna ``{transcricao, intencao_detectada,
+  endereco_mencionado, workflow_sugerido, suggested_reply_pt_br}``.
 
-Refs:
-    - ``prefeitura-rio/app-mcp-server`` PR feat/audio-transcription-via-gemini
-    - ``prefeitura-rio/study-sf-whatsapp-poc1`` ADR-015 (entrega audio E2E)
-    - ``src/prompt_modules/vision_inbound.py`` (módulo sibling pra imagem)
+Refator 2026-05-14 noite (ADR-018): bulk extraído pra
+``_analyzable_media_template.AnalyzableMediaSpec``. Aqui só audio-specific:
+allowlist Gemini audio, schema de análise, regra de não-pedir-repetir.
 """
+
+from src.prompt_modules._analyzable_media_template import (
+    AnalyzableMediaSpec,
+    render_module_prompt,
+)
 
 MODULE_NAME = "audio_inbound"
 
-MODULE_PROMPT = """## Transcrição de áudio inbound (extensão de mídia)
 
-Quando o passo anterior identificou ``media_type=audio`` (via
-``register_inbound_media`` do módulo "Recepção de mídia"), você PODE
-tentar transcrição via ``analyze_inbound_audio``. Decisão sobre chamá-la
-ou não segue a árvore abaixo.
+_AUDIO_GUIDANCE = """\
+### Schema da resposta `analyze_inbound_audio`
 
-### Decisão: chamar ``analyze_inbound_audio`` ou pular?
+```
+{
+  "transcricao": "<transcrição literal PT-BR>",
+  "resumo": "<1-2 frases>",
+  "idioma_detectado": "<pt-br|pt-pt|es|en|outro>",
+  "intencao_detectada": <true|false>,
+  "categoria": "<luminaria_publica|poda_arvore|buraco_via|lixo_irregular|iluminacao_publica|sinalizacao|endereco|duvida_geral|outro|nao_aplica>",
+  "endereco_mencionado": "<rua/bairro/número, vazio se não>",
+  "workflow_sugerido": "<reparo_luminaria | poda_de_arvore | nenhum>",
+  "confianca": "<alta|media|baixa>"
+}
+```
 
-**Chamar somente se TODAS as 2 condições forem verdadeiras:**
+### Allowlist Gemini audio input
 
-(a) A tool ``analyze_inbound_audio`` está disponível no seu toolset
-    (opt-in via ``ENABLE_AUDIO_ADDENDUM=true`` no MCP — se a tool não
-    estiver listada, ela não está disponível).
+Formatos suportados pela tool (espelhado do Gemini API):
+`oga`/`ogg` (PTT WhatsApp container OGG-Opus), `aac`, `mp3`, `wav`, `flac`,
+`aiff`/`aif`. **NÃO suportados**: `m4a` (MP4 audio), `amr` (codec deprecado).
+Se `media.file_extension` cair fora desse allowlist, **não chame a tool** e
+volte ao protocolo do módulo "Recepção de mídia".
 
-(b) Você tem ao menos UMA destas fontes de bytes do áudio
-    (em ordem de preferência):
+### Workflows triggerable a partir da transcrição
 
-    - ``meta_media_id`` no JSON do prefix ``[INBOUND_MEDIA]`` (campo
-      ``media.meta_media_id``). **Caminho canônico atual em produção
-      (ADR-017)** — cidadão veio via Meta webhook direto pro Mule.
-      A tool faz 2 GETs no Graph API (metadata + signed CDN URL) com
-      ``WA_TOKEN``. Handle automaticamente ``audio/ogg; codecs=opus``
-      (PTT WhatsApp).
-    - ``salesforce_download_path`` no JSON do prefix ``[INBOUND_MEDIA]``
-      (campo ``media.download_path``). Caminho UWC legacy — cidadão veio
-      via Salesforce UWC. A tool autentica via OAuth Client Credentials
-      e baixa direto do Salesforce REST API.
-    - ``audio_bytes_base64`` no contexto da mensagem (raro em produção
-      porque o LLM trunca strings >~10KB em tool args; útil só pra
-      testes manuais).
-    - ``local_audio_path`` no JSON do prefix (modo teste local com
-      upload manual em ``/tmp``, ``IS_LOCAL=true``).
+Use `analysis.workflow_sugerido` pra decidir:
 
-**Se qualquer condição falhar, NÃO chame a tool.** Volte inteiramente
-ao protocolo do módulo "Recepção de mídia" — ele já trata corretamente
-a distinção entre placeholder (use ``suggested_reply_pt_br`` do
-``register_inbound_media``) vs ``user_text`` real (use o ``user_text``
-como mensagem do cidadão, sem pedir pra ele repetir). Não há regressão
-nesse caminho. **Especificamente: se ``user_text`` veio com transcrição
-real upstream, NÃO chame ``analyze_inbound_audio`` nem peça pro cidadão
-repetir** — siga a partir do ``user_text``.
+- `reparo_luminaria` → confirme se `confianca >= media`, depois
+  `multi_step_service(service_name="reparo_luminaria")`.
+- `poda_de_arvore` → mesma lógica.
+- `nenhum` → use `analysis.transcricao` como mensagem real do cidadão e
+  continue o fluxo normal.
 
-> Em produção, **sempre passe ``salesforce_download_path``** quando ele
-> estiver presente no prefix ``[INBOUND_MEDIA]``. A tool baixa bytes via
-> SF REST sem você precisar copiar string longa via args.
+### REGRA: não pedir pro cidadão repetir o áudio em texto
 
-### Quando AS DUAS condições passam, executar transcrição
+`analysis.transcricao` é a mensagem real do cidadão — você acabou de
+"ouvir" o que ele falou. **NÃO peça pra digitar em texto o que ele já
+disse** ("manda em texto pra eu te ajudar"). Em vez disso, use a
+transcrição diretamente como o turno do cidadão e responda como
+responderia a texto.
 
-1. **Chamar ``analyze_inbound_audio``** logo após o
-   ``register_inbound_media``. **OBRIGATÓRIO** — sem isso o cidadão recebe
-   apenas o fallback genérico "não consigo transcrever áudio" do
-   ``register_inbound_media``, que NÃO É a resposta desejada quando há
-   áudio real:
+Quando `analysis.endereco_mencionado` está preenchido, o cidadão já
+forneceu o endereço por voz — pule a pergunta "qual o endereço?" e
+chame `validate_address(address=<endereco_mencionado>)` direto pra
+confirmar/geocodar antes de prosseguir com o workflow.
 
-   - ``user_number``: mesmo valor extraído do prefix ``[INBOUND_MEDIA]``
-   - ``message_id``: do prefix se disponível
-   - **SE o JSON ``media`` tem ``meta_media_id``** (canal canônico Meta direto):
-     - ``meta_media_id``: o valor (string) do campo ``media.meta_media_id``
-     - Não precisa de ``file_extension`` — tool deriva do MIME real do
-       Graph API (handle ``audio/ogg; codecs=opus`` automático).
-   - **SE o JSON ``media`` tem ``content_version_id``** (UWC legacy):
-     - ``file_extension``: do campo ``media.file_extension`` (**allowlist
-       Gemini**: ``oga``/``ogg``/``aac``/``mp3``/``wav``/``flac``/``aiff``;
-       NÃO ``m4a``/``amr``). Se fora do allowlist, NÃO chame a tool.
-     - ``content_version_id``: ``media.content_version_id``
-     - ``salesforce_download_path``: ``media.download_path``
-   - **SE ambos presentes**: passe ``meta_media_id`` (a tool prioriza esse caminho).
-
-   **REGRA CRÍTICA:** Quando o prefix `[INBOUND_MEDIA] type=audio` chegar, você TEM que chamar `analyze_inbound_audio` ALÉM de `register_inbound_media`. Chamar APENAS `register_inbound_media` resulta em resposta genérica "não consigo ouvir" — isso é regressão.
-
-2. **Usar a resposta da transcrição.** Retorno contém ``analysis`` com:
-
-   - ``transcricao``: o que o cidadão falou (literal, PT-BR)
-   - ``resumo``: 1-2 frases resumindo o pedido
-   - ``idioma_detectado``: ``pt-br``/``pt-pt``/``es``/``en``/``outro``
-   - ``intencao_detectada``: bool
-   - ``categoria``: ``luminaria_publica``/``poda_arvore``/``buraco_via``/
-     ``endereco``/``duvida_geral``/etc.
-   - ``endereco_mencionado``: endereço ou trecho identificado, ou ``""``
-   - ``workflow_sugerido``: ``reparo_luminaria``/``poda_de_arvore``/``nenhum``
-   - ``confianca``: ``alta``/``media``/``baixa``
-
-   E ``suggested_reply_pt_br`` baseado na análise. Use **esse**
-   ``suggested_reply_pt_br`` como base — NÃO o do
-   ``register_inbound_media`` (que é genérico).
-
-   **Trate ``analysis.transcricao`` como mensagem real do cidadão.**
-   Mesmo princípio do ``user_text`` real do módulo "Recepção de mídia":
-   não peça pra o cidadão repetir o que já falou em áudio.
-
-3. **Iniciar workflow se aplicável.** Se ``analysis.workflow_sugerido``
-   for ``reparo_luminaria`` ou ``poda_de_arvore`` E a ``confianca`` for
-   ``alta`` ou ``media``:
-
-   - Confirme com o cidadão o entendimento ("Ouvi que você está
-     reportando luminária queimada na Rua das Laranjeiras — confirma?").
-   - Se ``analysis.endereco_mencionado`` foi preenchido, **chame
-     ``validate_address`` direto com esse endereço** em vez de pedir o
-     endereço de novo (atalho importante — cidadão acabou de falar).
-   - Após confirmação, inicie via ``multi_step_service`` com o
-     ``service_name`` correspondente.
-
-4. **Fallback se transcrição falha ou é inconclusiva.** Se a tool
-   retornar erro, ``intencao_detectada=false``, ou ``confianca=baixa``,
-   peça ao cidadão pra repetir em texto. Não invente conteúdo que a
-   transcrição não revelou.
-
-### Exemplo de fluxo (áudio sobre luminária queimada)
+### Exemplo de fluxo (PTT com pedido de reparo via Meta direto)
 
 Entrada do cidadão:
-
 ```
-[INBOUND_MEDIA] type=audio user_number=5521989091014 media={"content_version_id":"068xx00000Bgd3T","file_extension":"oga","file_size_bytes":14509,"download_path":"/services/data/v62.0/sobjects/ContentVersion/068xx00000Bgd3T/VersionData"} | user_text=[Cidadao enviou uma mensagem de voz...]
+[INBOUND_MEDIA] type=audio user_number=5521989091014 media={"meta_media_id":"9876543210987654","mime_type":"audio/ogg; codecs=opus"} | user_text=[Cidadao enviou uma mensagem de voz...]
 ```
 
-Após ``register_inbound_media``, chame:
-
+Chamadas em sequência:
 ```
-analyze_inbound_audio(
-    user_number="5521989091014",
-    file_extension="oga",
-    content_version_id="068xx00000Bgd3T",
-    salesforce_download_path="/services/data/v62.0/sobjects/ContentVersion/068xx00000Bgd3T/VersionData",
-)
+register_inbound_media(media_type="audio", user_number="5521989091014",
+                       meta_media_id="9876543210987654", meta_mime_type="audio/ogg; codecs=opus")
+analyze_inbound_audio(user_number="5521989091014", meta_media_id="9876543210987654")
 ```
 
 Retorno típico:
-
 ```json
 {
   "status": "transcribed",
   "analysis": {
-    "transcricao": "tem uma luminária queimada na rua das laranjeiras",
-    "resumo": "Reporte de luminária queimada na Rua das Laranjeiras",
-    "idioma_detectado": "pt-br",
+    "transcricao": "tem uma luminária queimada na rua das laranjeiras 250 laranjeiras",
+    "resumo": "Cidadão relata luminária pública queimada na Rua das Laranjeiras, 250.",
     "intencao_detectada": true,
     "categoria": "luminaria_publica",
-    "endereco_mencionado": "rua das laranjeiras",
+    "endereco_mencionado": "Rua das Laranjeiras, 250, Laranjeiras",
     "workflow_sugerido": "reparo_luminaria",
     "confianca": "alta"
   },
-  "suggested_reply_pt_br": "Ouvi seu áudio: reporte de luminária queimada na Rua das Laranjeiras. Vou te ajudar a abrir um chamado de reparo de luminária — você confirma que quer prosseguir? Me passa o endereço (rua, número, bairro)."
+  "suggested_reply_pt_br": "Ouvi seu áudio: Cidadão relata luminária pública queimada na Rua das Laranjeiras, 250. Vou abrir o chamado de reparo de luminária no endereço que você mencionou (Rua das Laranjeiras, 250, Laranjeiras) — confirma?"
 }
 ```
-
-Sua resposta ao cidadão:
-
-> Entendi pelo áudio: luminária queimada na Rua das Laranjeiras.
-> Posso abrir o chamado de reparo. Pra confirmar, me passa o número
-> e o bairro completo?
-
-Se o cidadão responder "150, Laranjeiras", chame direto
-``validate_address(address="Rua das Laranjeiras 150, Laranjeiras")``
-sem pedir o nome da rua de novo — ele já disse no áudio.
 """
+
+
+_SPEC = AnalyzableMediaSpec(
+    module_name=MODULE_NAME,
+    media_type="audio",
+    analyze_tool="analyze_inbound_audio",
+    domain_noun_singular="áudio",
+    domain_noun_indefinite="um áudio",
+    domain_action="ouvir e transcrever",
+    domain_action_present="transcrição",
+    accepted_extensions=("oga", "ogg", "aac", "mp3", "wav", "flac", "aiff", "aif"),
+    rejected_extensions_note="**Não passa**: m4a (MP4 audio), amr (codec deprecado).",
+    bytes_base64_arg_name="audio_bytes_base64",
+    local_path_arg_name="local_audio_path",
+    enable_env_var="ENABLE_AUDIO_ADDENDUM",
+    skip_analyze_on_real_user_text=True,  # transcription upstream substitui análise
+    type_specific_guidance=_AUDIO_GUIDANCE,
+)
+
+
+MODULE_PROMPT = render_module_prompt(_SPEC)

--- a/src/prompt_modules/vision_inbound.py
+++ b/src/prompt_modules/vision_inbound.py
@@ -1,174 +1,117 @@
 """
 Módulo de prompt: instruções para o LLM chamar a tool MCP
 ``analyze_inbound_image`` (Gemini Vision) depois de ``register_inbound_media``
-quando o cidadão envia uma imagem via WhatsApp.
+quando o cidadão envia uma imagem real pelo WhatsApp.
 
-Contexto:
+Contexto upstream (resumido):
 
-* :mod:`src.prompt_modules.media_inbound` já instrui o LLM a chamar
-  ``register_inbound_media`` (stub de recepção/audit) quando vê o prefix
-  ``[INBOUND_MEDIA]``. Esse stub registra mas não analisa.
+* O módulo ``media_inbound`` já documenta o protocolo do prefix
+  ``[INBOUND_MEDIA]`` e instrui o LLM a chamar ``register_inbound_media``
+  (stub de recepção).
 * A tool MCP ``analyze_inbound_image`` (em
-  ``prefeitura-rio/app-mcp-server`` commit ``71202f62``, arquivo
-  ``src/tools/inbound_media_vision.py``) faz análise visual real via
-  Gemini Vision e classifica em workflows (``reparo_luminaria``,
-  ``poda_de_arvore``, ``nenhum``). É **opt-in** no MCP via flag
-  ``ENABLE_VISION_ADDENDUM=true`` — sem o flag a tool não é registrada e
-  o LLM nem a vê (instruções abaixo viram no-op).
+  ``prefeitura-rio/app-mcp-server/src/tools/inbound_media_vision.py``)
+  estende o stub: baixa via Meta CDN ou Salesforce REST, classifica
+  o problema via Gemini Vision, retorna ``{categoria, workflow_sugerido,
+  confianca, suggested_reply_pt_br}``.
 
-Quando a tool está registrada, o LLM deve chamar ela DEPOIS do
-``register_inbound_media`` mas ANTES de responder ao cidadão. O
-``suggested_reply_pt_br`` da análise visual substitui o do registro stub.
-
-**Limitação conhecida (fase atual):** ``analyze_inbound_image`` requer
-``image_bytes_base64`` ou ``local_image_path``. Em produção via Engine,
-nenhum dos dois é fornecido automaticamente pelo Gateway hoje (só
-``salesforce_download_path``). Até o Engine team implementar pré-fetch
-de bytes do Salesforce e injeção no contexto da mensagem, a tool pode
-retornar erro/análise vazia em prod. Mantemos a instrução pro LLM
-porque (a) staging com upload manual de bytes funciona, (b) quando o
-pre-fetch chegar (fase 2), nenhum redeploy de prompt será necessário.
-
-Refs:
-    - ``prefeitura-rio/app-mcp-server`` merge commit ``71202f62`` (PR #56)
-    - ``prefeitura-rio/study-sf-whatsapp-poc1`` ADR-012
-    - ``src/prompt_modules/media_inbound.py`` (módulo predecessor)
+Refator 2026-05-14 noite (ADR-018): bulk da estrutura do prompt
+(opt-in gate + call section + REGRA CRÍTICA) extraído pra
+``_analyzable_media_template.AnalyzableMediaSpec``. Este arquivo fica só
+com o que é vision-specific: schema do JSON de análise, regras de
+classificação visual, workflows sugeridos, exemplos.
 """
+
+from src.prompt_modules._analyzable_media_template import (
+    AnalyzableMediaSpec,
+    render_module_prompt,
+)
 
 MODULE_NAME = "vision_inbound"
 
-MODULE_PROMPT = """## Análise visual de imagem inbound (extensão de mídia)
 
-Quando o passo anterior identificou ``media_type=image`` (via
-``register_inbound_media`` do módulo "Recepção de mídia"), você PODE
-tentar análise visual via ``analyze_inbound_image``. Decisão sobre
-chamá-la ou não segue a árvore abaixo:
+_VISION_GUIDANCE = """\
+### Schema da resposta `analyze_inbound_image`
 
-### Decisão: chamar ``analyze_inbound_image`` ou pular?
-
-**Chamar somente se TODAS as 2 condições forem verdadeiras:**
-
-(a) A tool ``analyze_inbound_image`` está disponível no seu toolset
-    (opt-in via ``ENABLE_VISION_ADDENDUM=true`` no MCP — se a tool não
-    estiver listada, ela não está disponível).
-
-(b) Você tem ao menos UMA destas fontes de bytes da imagem
-    (em ordem de preferência):
-
-    - ``meta_media_id`` no JSON do prefix ``[INBOUND_MEDIA]`` (campo
-      ``media.meta_media_id``). **Caminho canônico atual em produção
-      (ADR-017)** — cidadão veio via Meta webhook direto pro Mule.
-      A tool faz 2 GETs no Graph API (metadata + signed CDN URL) com
-      ``WA_TOKEN``, sem precisar do Salesforce.
-    - ``salesforce_download_path`` no JSON do prefix ``[INBOUND_MEDIA]``
-      (campo ``media.download_path``). Caminho UWC legacy — cidadão veio
-      via Salesforce UWC. A tool autentica via OAuth Client Credentials
-      e baixa direto do Salesforce REST API.
-    - ``image_bytes_base64`` no contexto da mensagem (raro em produção
-      porque o LLM trunca strings >~10KB em tool args; útil só pra
-      testes manuais).
-    - ``local_image_path`` no JSON do prefix ``[INBOUND_MEDIA]`` (modo
-      teste local com upload manual em ``/tmp``, ``IS_LOCAL=true``).
-
-**Se qualquer uma das 2 condições falhar, NÃO chame a tool.** Volte
-inteiramente ao protocolo do módulo "Recepção de mídia" — ele já trata
-corretamente a distinção entre placeholder (use ``suggested_reply_pt_br``
-do registro) vs caption real (use o ``user_text`` como mensagem do
-cidadão, sem pedir pra repetir). Não há regressão nesse caminho.
-
-> Em produção, **sempre passe ``salesforce_download_path``** quando ele
-> estiver presente no prefix ``[INBOUND_MEDIA]``. A tool baixa bytes via
-> SF REST sem você precisar copiar string longa via args (que o modelo
-> tende a truncar).
-
-### Quando AS DUAS condições passam, executar análise
-
-1. **Chamar ``analyze_inbound_image``** logo após o ``register_inbound_media``. **OBRIGATÓRIO** — sem isso o cidadão recebe apenas o fallback genérico "não consigo analisar fotos" do `register_inbound_media`, que NÃO É a resposta desejada quando há foto real:
-
-   - ``user_number``: mesmo valor extraído do prefix ``[INBOUND_MEDIA]``
-   - ``message_id``: do prefix se disponível (audit cross-ref)
-   - **SE o JSON ``media`` tem ``meta_media_id``** (canal canônico Meta direto, ADR-017):
-     - ``meta_media_id``: o valor (string) do campo ``media.meta_media_id``
-     - Não precisa de ``file_extension`` (tool deriva do MIME real do Graph API)
-   - **SE o JSON ``media`` tem ``content_version_id``** (UWC legacy):
-     - ``content_version_id``: ``media.content_version_id``
-     - ``file_extension``: ``media.file_extension``
-     - ``salesforce_download_path``: ``media.download_path``
-   - **SE ambos presentes**: passe ``meta_media_id`` (a tool prioriza esse caminho).
-
-   **REGRA CRÍTICA:** Quando o prefix `[INBOUND_MEDIA] type=image` chegar, você TEM que chamar `analyze_inbound_image` ALÉM de `register_inbound_media`. Chamar APENAS `register_inbound_media` resulta em resposta genérica "não consigo analisar fotos" — isso é regressão, não comportamento esperado.
-
-2. **Usar a resposta da análise.** O retorno contém ``analysis`` com:
-
-   - ``descricao``: o que a foto mostra
-   - ``problema_detectado``: bool
-   - ``categoria``: ``luminaria_publica``/``poda_arvore``/``buraco_via``/etc.
-   - ``workflow_sugerido``: ``reparo_luminaria``/``poda_de_arvore``/``nenhum``
-   - ``confianca``: ``alta``/``media``/``baixa``
-
-   E ``suggested_reply_pt_br`` baseado na análise. Use **esse**
-   ``suggested_reply_pt_br`` (da análise visual) como base da resposta
-   ao cidadão — NÃO o do ``register_inbound_media``, que é genérico.
-
-   Se ``user_text`` veio com caption real do cidadão, **combine**: cite
-   tanto o que viu na imagem quanto o que o cidadão disse, sem pedir
-   pra ele repetir o que já escreveu.
-
-3. **Iniciar workflow se aplicável.** Se
-   ``analysis.workflow_sugerido`` for ``reparo_luminaria`` ou
-   ``poda_de_arvore`` E a ``confianca`` for ``alta`` ou ``media``:
-
-   - Confirme com o cidadão a categoria detectada antes de iniciar o
-     workflow ("Vi uma luminária com o globo quebrado — confirma que
-     é isso?").
-   - Após confirmação, inicie via ``multi_step_service`` com o
-     ``service_name`` correspondente.
-
-4. **Fallback se análise falha ou é inconclusiva.** Se a tool retornar
-   erro, ``problema_detectado=false`` com ``categoria=nao_aplica``, ou
-   ``confianca=baixa``, **volte ao protocolo do módulo "Recepção de
-   mídia"** (mesmo princípio do "tool indisponível" acima — não invente
-   diagnóstico não suportado pela análise; se há ``user_text`` real,
-   continue a partir dele).
-
-### Exemplo de fluxo (imagem de luminária quebrada)
-
-Após ``register_inbound_media`` ter sido chamado para a imagem,
-você chama:
+O `analysis` retornado tem o seguinte schema:
 
 ```
-analyze_inbound_image(
-    user_number="5521989091014",
-    file_extension="jpg",
-    content_version_id="0688800000Bgd3T",
-    salesforce_download_path="/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3T/VersionData",
-)
+{
+  "descricao": "<o que a foto mostra, max 200 chars>",
+  "problema_detectado": <true|false>,
+  "categoria": "<luminaria_publica | poda_arvore | buraco_via | lixo_irregular | iluminacao_publica | sinalizacao | outro | nao_aplica>",
+  "detalhes": "<o que parece estar errado, max 250 chars>",
+  "workflow_sugerido": "<reparo_luminaria | poda_de_arvore | nenhum>",
+  "confianca": "<alta|media|baixa>"
+}
+```
+
+### Workflows triggerable a partir da análise visual
+
+Use `analysis.workflow_sugerido` pra decidir o próximo passo:
+
+- `reparo_luminaria` → confirme com o cidadão a categoria detectada
+  ("Vi uma luminária com o globo quebrado — confirma que é isso?"),
+  depois chame `multi_step_service(service_name="reparo_luminaria")`.
+- `poda_de_arvore` → confirme, depois
+  `multi_step_service(service_name="poda_de_arvore")`.
+- `nenhum` → use o `suggested_reply_pt_br` da análise como base e siga o
+  fluxo conversacional normal.
+
+**Sempre confirme a categoria antes de disparar o workflow.** Análise
+visual pode estar errada, especialmente com `confianca=media` ou `baixa`.
+
+### Composição da resposta
+
+- Se `user_text` veio com caption real do cidadão, **combine**: cite tanto
+  o que viu na imagem quanto o que ele disse, sem pedir pra repetir.
+- Se `confianca=baixa` ou `problema_detectado=false`, peça descrição em
+  texto pra confirmar.
+
+### Exemplo de fluxo (imagem de luminária quebrada via Meta direto)
+
+Entrada do cidadão:
+```
+[INBOUND_MEDIA] type=image user_number=5521989091014 media={"meta_media_id":"1234567890123456","mime_type":"image/jpeg"} | user_text=[Cidadao enviou uma imagem...]
+```
+
+Chamadas em sequência:
+```
+register_inbound_media(media_type="image", user_number="5521989091014",
+                       meta_media_id="1234567890123456", meta_mime_type="image/jpeg")
+analyze_inbound_image(user_number="5521989091014", meta_media_id="1234567890123456")
 ```
 
 Retorno típico:
-
 ```json
 {
-  "status": "ok",
+  "status": "analyzed",
   "analysis": {
     "descricao": "Poste de luminária pública com lâmpada quebrada",
     "problema_detectado": true,
     "categoria": "luminaria_publica",
-    "detalhes": "Vidro do globo da luminária quebrado, lâmpada visível",
     "workflow_sugerido": "reparo_luminaria",
     "confianca": "alta"
   },
   "suggested_reply_pt_br": "Vi na foto que a luminária pública está com o globo quebrado. Posso abrir o pedido de reparo pra você? Me confirma o endereço (rua, número, bairro) e a gente segue."
 }
 ```
-
-Sua resposta ao cidadão (adaptando o ``suggested_reply_pt_br``):
-
-> Olhei sua foto — luminária com globo quebrado, anotado.
-> Pra abrir o pedido de reparo preciso do endereço (rua, número, bairro).
-> Pode me passar?
-
-Depois da confirmação do endereço, chame
-``multi_step_service(service_name="reparo_luminaria", user_id=user_number, payload=...)``
-pra iniciar o workflow.
 """
+
+
+_SPEC = AnalyzableMediaSpec(
+    module_name=MODULE_NAME,
+    media_type="image",
+    analyze_tool="analyze_inbound_image",
+    domain_noun_singular="imagem",
+    domain_noun_indefinite="uma imagem",
+    domain_action="analisar",
+    domain_action_present="análise",
+    accepted_extensions=("jpg", "jpeg", "png", "webp", "gif"),
+    bytes_base64_arg_name="image_bytes_base64",
+    local_path_arg_name="local_image_path",
+    enable_env_var="ENABLE_VISION_ADDENDUM",
+    type_specific_guidance=_VISION_GUIDANCE,
+)
+
+
+MODULE_PROMPT = render_module_prompt(_SPEC)


### PR DESCRIPTION
Generalização ADR-018. Vision/audio prompt modules tinham ~60% sobreposição (gate, byte sources, REGRA CRITICA, fallback). Extrai pra _analyzable_media_template.py (193 LOC reusable).

## Sumario
- vision: 174 -> 116 LOC (-33%)
- audio: 182 -> 126 LOC (-31%)
- AnalyzableMediaSpec dataclass (config per-domain)
- render_module_prompt(spec) gera MODULE_PROMPT
- skip_analyze_on_real_user_text per-spec (audio=True, vision=False — caption ≠ análise visual)
- enable_env_var explicito (vision=ENABLE_VISION_ADDENDUM, audio=ENABLE_AUDIO_ADDENDUM)

## Test plan
- [x] pytest tests/unit/test_prompt_modules.py -> 35 passing
- [x] Codex review iterativo (3 P2s endereçados)
- [ ] Smoke E2E pós-deploy: comportamento Gemini Vision sem regressão

🤖 Generated with Claude Code