### PR TITLE
fix(eval): regex \s em raw string + markdown parse no comment de deploy

### DIFF
--- a/.github/scripts/parse_pr_comment.py
+++ b/.github/scripts/parse_pr_comment.py
@@ -9,7 +9,16 @@ for c in sorted(comments, key=lambda x: x.get("created_at", ""), reverse=True):
     if "REASONING_ENGINE_ID" not in body:
         continue
     m_env = re.search(r"Environment[^a-zA-Z0-9]*([a-zA-Z0-9_-]+)", body, re.IGNORECASE)
-    m_id = re.search(r"REASONING_ENGINE_ID\\s*:\\s*`?([^`\\s]+)`?", body, re.IGNORECASE)
+    # Deploy comment format:
+    #   `**REASONING_ENGINE_ID:** `<id>``
+    # Match the keyword, skip arbitrary punctuation/whitespace/markdown
+    # (`**`, `:`, spaces), then capture the value either inside backticks
+    # (preferred) or as the next non-whitespace, non-backtick token.
+    m_id = re.search(
+        r"REASONING_ENGINE_ID[\s*:`]*([^`\s*]+)`?",
+        body,
+        re.IGNORECASE,
+    )
     if not m_id:
         continue
     env = (m_env.group(1) if m_env else "").strip().lower()


### PR DESCRIPTION
## Summary

**Causa raiz** do "Evals failed" reportado em todos os deploys recentes (incluindo PR #53 hoje):

`parse_pr_comment.py:12` usava `\\s` em raw string Python — vira literal `\s` (2 chars), não o regex `\s` (whitespace class). Resultado: regex nunca batia, todo deploy disparava `"No deploy comment with REASONING_ENGINE_ID found"` e falhava o `eval-on-deploy.yml`.

```python
# Antes (buggy):
m_id = re.search(r"REASONING_ENGINE_ID\\s*:\\s*`?([^`\\s]+)`?", body, re.IGNORECASE)
# Em raw string, \\s não é classe whitespace — é literal "\s"

# Depois:
m_id = re.search(r"REASONING_ENGINE_ID[\s*:`]*([^`\s*]+)`?", body, re.IGNORECASE)
```

Fix também cobre o markdown wrapping `**REASONING_ENGINE_ID:**` gerado por `deploy-on-command.yml` — o pattern antigo, mesmo com escape correto, capturava o `**` de fechamento ao invés do ID (P1 detectado em codex review).

## Test plan

Validado contra 3 sample bodies via repl:

| Body | Captured |
|---|---|
| Comment prod `**REASONING_ENGINE_ID:** \`6881320460470976512\`` | `6881320460470976512` ✓ |
| Plain text `REASONING_ENGINE_ID: 1234567890` | `1234567890` ✓ |
| KV `REASONING_ENGINE_ID=plain_98765` | `=plain_98765` (edge case, não usado pelo deploy bot) |

Próximo deploy real deveria mostrar evals rodando (em vez de falhar imediatamente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)