### PR TITLE
feat(prompt-modules): whatsapp_flow_inbound — reforço system prompt

### DIFF
--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -30,7 +30,12 @@ específicas que devem viver ao lado do código de tools.
 
 from typing import Tuple
 
-from src.prompt_modules import audio_inbound, media_inbound, vision_inbound
+from src.prompt_modules import (
+    audio_inbound,
+    media_inbound,
+    vision_inbound,
+    whatsapp_flow_inbound,
+)
 
 # Ordem importa — define a sequência em que cada módulo aparece no prompt
 # final. Pra desabilitar um módulo, removê-lo desta lista (não comentar
@@ -41,10 +46,16 @@ from src.prompt_modules import audio_inbound, media_inbound, vision_inbound
 # DEPOIS. O suggested_reply de analyze_inbound_image/_audio substitui o do
 # register_inbound_media — a ordem das instruções no prompt importa pro LLM
 # resolver o "qual usar".
+#
+# whatsapp_flow_inbound é independente dos demais (próprio protocolo
+# `[FLOW_COMPLETION]`, próprio dispatcher MCP). Ordenado por último —
+# media_inbound prefix dá precedência em casos ambíguos (improvável mas
+# concebível se um flow_name fizer match com palavra de prefix media).
 ENABLED_MODULES = [
     media_inbound,
     vision_inbound,
     audio_inbound,
+    whatsapp_flow_inbound,
 ]
 
 

--- a/src/prompt_modules/whatsapp_flow_inbound.py
+++ b/src/prompt_modules/whatsapp_flow_inbound.py
@@ -1,0 +1,95 @@
+"""
+Prompt module — reforço da instrução inline do Mule pra WhatsApp Flow completion.
+
+Quando o cidadão preenche um WhatsApp Flow e envia, o Meta dispara
+`interactive.nfm_reply` no webhook. O Mule (`process-whatsapp-flow-completion`
+em `sc-inbound-flow.xml`, ADR-014/ADR-019) encaminha pro Gateway com
+formato:
+
+    [SYSTEM] O cidadão preencheu o formulário WhatsApp. Dados recebidos:
+    {"defect_type":"Apagada","qty_pattern":"uma"}. AÇÃO OBRIGATÓRIA: Chame a
+    ferramenta multi_step_service imediatamente com esses dados no campo
+    'payload' (adicione _source='whatsapp_flow'). Identifique o
+    service_name correto baseado nos campos recebidos.
+
+A instrução inline funciona razoavelmente bem, mas Gemini Flash pode
+ignorar imperativas in-message em troca de responder textualmente
+("Recebi seu formulário..."). Este módulo eleva o protocolo pro
+system prompt (mais forte que inline) e fornece mapeamento explícito
+campos → service_name (LLM não precisa adivinhar).
+
+Workflow consumer-side (`reparo_luminaria/workflow.py`) já tem aliases
+`defect_type → luminaria_defeito`, `qty_pattern → quantidade +
+intercaladas_bloco`, `location → luminaria_localizacao` quando
+`_source=whatsapp_flow` (commit 383352b da Gabs). Então o LLM só precisa
+chamar `multi_step_service(service_name, user_id, payload=flow_dados + _source)`
+— o resto é interno.
+"""
+
+MODULE_NAME = "whatsapp_flow_inbound"
+
+MODULE_PROMPT = """\
+## Submissão de WhatsApp Flow (`multi_step_service` direto)
+
+Quando a mensagem do cidadão começar com `[SYSTEM] O cidadão preencheu o formulário WhatsApp`, **NÃO** trate como texto normal e **NÃO** responda ao cidadão antes da tool call. Siga este protocolo:
+
+1. **Extraia o JSON `Dados recebidos`** da mensagem. Exemplo:
+   ```
+   [SYSTEM] O cidadão preencheu o formulário WhatsApp. Dados recebidos: {"defect_type":"Apagada","qty_pattern":"uma"}. AÇÃO OBRIGATÓRIA: ...
+   ```
+   → JSON extraído: `{"defect_type":"Apagada","qty_pattern":"uma"}`
+
+2. **Identifique `service_name` pelos campos do JSON.** Mapeamento canônico:
+
+   | Campos presentes | `service_name` |
+   |---|---|
+   | `defect_type`, `qty_pattern`, `location` (qualquer um) | `reparo_luminaria` |
+   | (futuros campos de poda) | `poda_de_arvore` |
+   | (futuros campos de IPTU) | `iptu_pagamento` |
+
+   Se nenhum mapeamento bate, default = `reparo_luminaria` (único Flow registrado no Meta hoje — `FLOW_LUMINARIA_ID=4141008006029185`). Logue warning mental sobre flow_id desconhecido.
+
+3. **Chame `multi_step_service` IMEDIATAMENTE** (antes de qualquer texto pro cidadão):
+
+   ```
+   multi_step_service(
+     service_name="<mapeado no passo 2>",
+     user_id="<telefone do cidadão, E.164 sem '+'>",
+     payload={
+       **<json extraído do passo 1>,
+       "_source": "whatsapp_flow"
+     }
+   )
+   ```
+
+   **CRÍTICO `_source="whatsapp_flow"`:** sem isso, o workflow auto-trigger reenvia o Flow ao cidadão (loop). O `multi_step_service` já tem lógica `workflow_is_active` + `is_new_request` (commits 9dc6e6c/e0e56b9/13bd660 da Gabs) que evita re-envio quando `_source=whatsapp_flow` no payload.
+
+4. **Use o retorno do `multi_step_service` como base da resposta ao cidadão.** O workflow internalmente faz alias dos campos (`defect_type → luminaria_defeito`, `qty_pattern → luminaria_quantidade + luminaria_intercaladas_bloco`, `location → luminaria_localizacao`), avança o state, e retorna a próxima pergunta (ex: "Onde está localizada a luminária? 1. Calçada...").
+
+   Combine: (a) ack curto do form ("Recebi seu formulário."), (b) string retornada pelo `multi_step_service`. NÃO invente pergunta — use a que o workflow retornou.
+
+### Exemplo end-to-end
+
+```
+USER: [SYSTEM] O cidadão preencheu o formulário WhatsApp. Dados recebidos: {"defect_type":"Apagada","qty_pattern":"uma"}. AÇÃO OBRIGATÓRIA: Chame a ferramenta multi_step_service imediatamente com esses dados no campo 'payload' (adicione _source='whatsapp_flow'). Identifique o service_name correto baseado nos campos recebidos.
+
+ASSISTANT (tool call PRIMEIRO, sem texto):
+multi_step_service(
+  service_name="reparo_luminaria",
+  user_id="5521989091014",
+  payload={"defect_type": "Apagada", "qty_pattern": "uma", "_source": "whatsapp_flow"}
+)
+
+TOOL RETURNS: "Onde está localizada a luminária com defeito? Escolha uma opção:\\n1. Calçada\\n2. Fachada\\n..."
+
+ASSISTANT (texto AO CIDADÃO):
+Recebi seu formulário! Onde está localizada a luminária com defeito? Escolha uma opção:
+1. Calçada
+2. Fachada
+...
+```
+
+### REGRA CRÍTICA
+
+NUNCA responda ao cidadão antes de chamar `multi_step_service` quando vir o prefix `[SYSTEM] O cidadão preencheu o formulário WhatsApp`. NUNCA pule o `_source="whatsapp_flow"` no payload — sem ele você causa loop infinito de re-envio do Flow.
+"""


### PR DESCRIPTION
## Summary

Novo prompt module `whatsapp_flow_inbound` que reforça a instrução inline do Mule pra WhatsApp Flow completion ([ADR-020 no study-sf](https://github.com/prefeitura-rio/study-sf-whatsapp-poc1/blob/main/docs/decisoes/020-whatsapp-flow-generalizacao-e-outbound.md)).

## Por que

O Mule envia `[SYSTEM] O cidadão preencheu o formulário WhatsApp... AÇÃO OBRIGATÓRIA: Chame multi_step_service imediatamente...` (commit a15550d Gabryelle no study-sf-whatsapp-poc1). Mas instrução inline em cada mensagem é frágil — Gemini Flash pode ignorar e responder textualmente.

Este module eleva o protocolo a system prompt:
- Mapeamento canônico campos → `service_name` (`defect_type/qty_pattern/location` → `reparo_luminaria`)
- Instrução `multi_step_service` direto com `_source=whatsapp_flow` no payload (evita auto-trigger loop com a logic do Gabs em commit 9dc6e6c)
- Regra: combinar ack do form + string retornada pelo workflow (evita pular pergunta esperada)

## Test plan

- [x] 35/35 `test_prompt_modules.py` pass
- [x] Codex review clean
- [ ] Próximo deploy do engine via `/deploy staging` vai aplicar este prompt module
- [ ] E2E real: William envia Flow luminária pelo WhatsApp → bot processa via novo prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)