### PR TITLE
ci: workflow_dispatch pra cleanup de reasoning engines

### DIFF
--- a/.github/workflows/cleanup-engines.yml
+++ b/.github/workflows/cleanup-engines.yml
@@ -1,0 +1,112 @@
+name: Cleanup Old Reasoning Engines
+
+# Inputs (inputs.count, inputs.dry_run) sao passados via env vars
+# (INPUT_COUNT, INPUT_DRY_RUN) pro shell — sem interpolacao direta no
+# bloco `run`, alinhado com guia de seguranca pra GH Actions.
+on:
+  workflow_dispatch:
+    inputs:
+      count:
+        description: "Quantos engines deletar (mais antigos primeiro). Default 10."
+        required: false
+        default: "10"
+        type: string
+      dry_run:
+        description: "Apenas listar; nao deletar"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  # Serializa execucoes: cleanup eh destrutivo, dispatches concorrentes
+  # poderiam apagar engines re-listados entre o guard e o delete. Cancel
+  # in-progress nao — esperar o anterior terminar e a fila descer.
+  group: cleanup-engines-${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Export secrets from Infisical
+        uses: Infisical/secrets-action@v1.0.15
+        with:
+          method: universal
+          client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
+          client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          project-slug: ${{ secrets.INFISICAL_PROJECT_SLUG }}
+          env-slug: staging
+          domain: ${{ secrets.INFISICAL_URL }}
+
+      - name: Decode GCP service account key
+        run: |
+          set -e
+          printf '%s' "$GCP_SA_KEY" | tr -d '[:space:]' | base64 -d > /tmp/gcp-key.json
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-key.json" >> $GITHUB_ENV
+
+      - name: Run cleanup
+        env:
+          INPUT_COUNT: ${{ inputs.count }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -e
+          # Valida count como integer positivo. Script usa engines[:count] —
+          # valor negativo ou nao-numerico apaga conjunto diferente do que
+          # operador esperava. Limita a 1-50 strings (max 2 digitos) pra
+          # nao precisar lidar com Bash integer overflow (numeros muito
+          # grandes quebrariam `[ -gt 50 ]` e o `set -e` nao captura porque
+          # o teste esta dentro de `if`).
+          if ! [[ "$INPUT_COUNT" =~ ^([1-9]|[1-4][0-9]|50)$ ]]; then
+            echo "ERROR: count input must be an integer in [1, 50], got: '$INPUT_COUNT'" >&2
+            exit 1
+          fi
+
+          # Active engine guard: lista engines e verifica se o
+          # REASONING_ENGINE_ID atual (do Infisical) esta entre os
+          # INPUT_COUNT mais antigos que serao deletados. Se sim, aborta —
+          # operador deve aumentar INPUT_COUNT ou rotacionar o ID antes.
+          if [ -z "${REASONING_ENGINE_ID:-}" ]; then
+            echo "ERROR: REASONING_ENGINE_ID nao definido no env (Infisical)" >&2
+            exit 1
+          fi
+          echo "Active engine: $REASONING_ENGINE_ID"
+          uv run python -c "
+          import os, sys
+          from vertexai import agent_engines
+          import vertexai
+          vertexai.init(project=os.environ['PROJECT_ID'], location=os.environ['LOCATION'])
+          active_id = os.environ['REASONING_ENGINE_ID']
+          count = int(os.environ['INPUT_COUNT'])
+          engines = list(agent_engines.list())
+          engines.sort(key=lambda e: e.create_time)
+          oldest_ids = [e.resource_name.split('/')[-1] for e in engines[:count]]
+          if active_id in oldest_ids:
+              print(f'FATAL: active engine {active_id} esta entre os {count} mais antigos que seriam apagados — rotacione o REASONING_ENGINE_ID atual ou reduza count', file=sys.stderr)
+              sys.exit(1)
+          print(f'OK: active {active_id} nao esta no batch de delete (engines a apagar: {oldest_ids})')
+          "
+
+          DRY_FLAG=""
+          if [ "$INPUT_DRY_RUN" = "true" ]; then
+            DRY_FLAG="--dry-run"
+          fi
+          echo "Running cleanup: count=$INPUT_COUNT dry_run=$INPUT_DRY_RUN"
+          # Script tem `input("Type 'DELETE' to confirm:")` interativo; GH
+          # Actions nao tem stdin. Pipe 'DELETE' pra passar a confirmacao
+          # non-interactively.
+          echo "DELETE" | uv run src/utils/cleanup_reasoning_engines.py \
+            --count "$INPUT_COUNT" $DRY_FLAG


### PR DESCRIPTION
## Summary

Workflow novo pra triggerar `cleanup_reasoning_engines.py` via GH Actions (sem precisar de credenciais locais). **Necessário porque atingimos quota** `ReasoningEngineEntitiesPerProjectPerRegion` de Vertex AI após múltiplos deploys hoje (run [25923428447](https://github.com/prefeitura-rio/app-eai-agent-engine/actions/runs/25923428447) falhou com 429 ResourceExhausted).

## Guards (4 ciclos de codex review aplicados antes do credit limit)

- **Count validation**: regex `^([1-9]|[1-4][0-9]|50)$` — aceita só integers 1-50 (rejeita números muito grandes que quebrariam Bash arithmetic)
- **Active engine guard**: inline Python lista engines, verifica que `REASONING_ENGINE_ID` do Infisical NÃO está entre os N mais antigos pra delete. Aborta se estaria.
- **Concurrency lock serial** (`cancel-in-progress: false`) — evita race entre 2 dispatches concorrentes (P2 codex 5° ciclo)
- **Inputs por env vars** — sem interpolação direta de `${{ inputs.X }}` no shell
- **Pipe 'DELETE' confirmation** — resolve prompt interativo do script em GH Actions sem stdin

## How to use

```bash
# Dry-run pra ver quais engines seriam apagados
gh workflow run cleanup-engines.yml -f count=10 -f dry_run=true

# Apagar real
gh workflow run cleanup-engines.yml -f count=10
```

Ou via GH UI (Actions → Cleanup Old Reasoning Engines → Run workflow).

## Test plan

- [x] 4 ciclos de codex review pré-credit-limit — endereçados counts inválidos, prompt interativo, active engine guard, race condition
- [ ] Dry-run primeiro pra validar empiricamente
- [ ] Cleanup real pra liberar quota e destravar PR #55 deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)