### PR TITLE
feat(prompt-modules): video_inbound — analise de video via Gemini multimodal

### DIFF
--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -33,6 +33,7 @@ from typing import Tuple
 from src.prompt_modules import (
     audio_inbound,
     media_inbound,
+    video_inbound,
     vision_inbound,
     whatsapp_flow_inbound,
 )
@@ -55,6 +56,7 @@ ENABLED_MODULES = [
     media_inbound,
     vision_inbound,
     audio_inbound,
+    video_inbound,
     whatsapp_flow_inbound,
 ]
 

--- a/src/prompt_modules/media_inbound.py
+++ b/src/prompt_modules/media_inbound.py
@@ -46,7 +46,7 @@ Quando a entrada do cidadão começar com `[INBOUND_MEDIA]`, **NÃO** trate como
    [INBOUND_MEDIA] type=<media_type> user_number=<phone> media=<json> | user_text=<placeholder>
    ```
 
-   - `media_type` ∈ `{image, audio, location, unsupported, unknown}`
+   - `media_type` ∈ `{image, audio, video, location, unsupported, unknown}`
    - `user_number`: E.164 sem `+` (ex: `5521989091014`)
    - `media`: objeto JSON com metadados (pode ser `null` para `unsupported`/`unknown`)
    - `user_text`: conteúdo textual associado à mídia. **Atenção:** pode ser **placeholder gerado upstream** (quando nada de texto real veio do cidadão) ou **conteúdo real** (caption de imagem, transcrição de áudio, etc.).
@@ -77,9 +77,10 @@ Quando a entrada do cidadão começar com `[INBOUND_MEDIA]`, **NÃO** trate como
 4. **Use as tools de análise quando aplicável.** A tool `register_inbound_media` é stub de recepção (apenas registra audit + retorna sugestão). Para análise real:
    - **Imagem:** chame `analyze_inbound_image` em seguida, quando disponível (conforme módulo `vision_inbound` deste prompt).
    - **Áudio:** chame `analyze_inbound_audio` em seguida, quando disponível (conforme módulo `audio_inbound` deste prompt) — a tool transcreve a fala e retorna intenção + workflow sugerido.
+   - **Vídeo:** chame `analyze_inbound_video` em seguida, quando disponível (conforme módulo `video_inbound` deste prompt) — a tool analisa frames + áudio do vídeo e retorna descrição + transcrição + workflow sugerido.
    - **Localização:** ainda não tem caminho de processamento direto — siga o protocolo de geocoding via texto descrito mais abaixo (caso `media_type=unsupported`).
 
-   Quando o módulo correspondente (`vision_inbound`/`audio_inbound`) estiver presente neste prompt e a tool estiver listada, use-os. Quando o módulo NÃO estiver presente OU a tool NÃO estiver listada, mantenha o fallback genérico do `register_inbound_media` (mensagem amigável pedindo texto).
+   Quando o módulo correspondente (`vision_inbound`/`audio_inbound`/`video_inbound`) estiver presente neste prompt e a tool estiver listada, use-os. Quando o módulo NÃO estiver presente OU a tool NÃO estiver listada, mantenha o fallback genérico do `register_inbound_media` (mensagem amigável pedindo texto).
 
 ### Caso especial: `media_type=unsupported` (geocoding via texto)
 

--- a/src/prompt_modules/video_inbound.py
+++ b/src/prompt_modules/video_inbound.py
@@ -1,0 +1,97 @@
+"""
+Módulo de prompt: instruções para o LLM chamar a tool MCP
+``analyze_inbound_video`` (Gemini multimodal video) depois de
+``register_inbound_media`` quando o cidadão envia um vídeo pelo WhatsApp.
+
+Estrutura espelha ``vision_inbound`` / ``audio_inbound`` via
+``AnalyzableMediaSpec`` (ADR-018). Este arquivo fica só com o que é
+video-specific: schema do JSON de análise, regras de classificação
+visual/auditiva, workflows sugeridos.
+"""
+
+from src.prompt_modules._analyzable_media_template import (
+    AnalyzableMediaSpec,
+    render_module_prompt,
+)
+
+MODULE_NAME = "video_inbound"
+
+
+_VIDEO_GUIDANCE = """\
+### Schema da resposta `analyze_inbound_video`
+
+O `analysis` retornado tem o seguinte schema:
+
+```
+{
+  "descricao": "<o que o video mostra, max 250 chars>",
+  "problema_detectado": <true|false>,
+  "categoria": "<luminaria_publica | poda_arvore | buraco_via | lixo_irregular | iluminacao_publica | sinalizacao | enchente_alagamento | outro | nao_aplica>",
+  "detalhes": "<o que parece estar errado, max 300 chars>",
+  "transcricao_audio": "<transcricao fiel do que o cidadao falou, max 500 chars; vazio se nao ha fala>",
+  "workflow_sugerido": "<reparo_luminaria | poda_de_arvore | nenhum>",
+  "confianca": "<alta|media|baixa>"
+}
+```
+
+### Workflows triggerable a partir da análise do vídeo
+
+Use `analysis.workflow_sugerido` pra decidir o próximo passo:
+
+- `reparo_luminaria` → confirme + chame
+  `multi_step_service(service_name="reparo_luminaria")`. Se
+  `analysis.transcricao_audio` mencionar endereço, considere chamar
+  `validate_address` direto.
+- `poda_de_arvore` → confirme + chame
+  `multi_step_service(service_name="poda_de_arvore")`.
+- `nenhum` → use `analysis.descricao` (e `transcricao_audio` se houver)
+  como mensagem real do cidadão. **NÃO** peça pra repetir em texto o
+  que já foi mostrado/falado no vídeo. Continue o atendimento normal
+  baseado no contexto.
+
+### Confiança como guia
+
+- `alta` → siga sem pedir confirmação extra.
+- `media` → confirme a interpretação com o cidadão antes de abrir
+  chamado ("Pelo vídeo entendi X — confirma?").
+- `baixa` → peça mais detalhes ou outra foto/ângulo se relevante.
+
+### Exemplo de uso
+
+Cidadão envia vídeo de luminária piscando à noite, com áudio
+"essa luminária na frente do número 30 está piscando há dias":
+
+```
+analysis = {
+  "descricao": "Vídeo noturno mostrando poste com luminária piscando intermitentemente",
+  "problema_detectado": true,
+  "categoria": "luminaria_publica",
+  "detalhes": "Luminária piscando, falha intermitente; cidadão menciona endereço",
+  "transcricao_audio": "essa luminária na frente do número 30 está piscando há dias",
+  "workflow_sugerido": "reparo_luminaria",
+  "confianca": "alta"
+}
+```
+
+Próximo passo do LLM: "Recebi seu vídeo, a luminária está piscando — vou abrir um chamado de reparo. Pode confirmar o endereço (você mencionou número 30)?" + `validate_address` quando o cidadão completar.
+"""
+
+
+_SPEC = AnalyzableMediaSpec(
+    module_name=MODULE_NAME,
+    media_type="video",
+    analyze_tool="analyze_inbound_video",
+    domain_noun_singular="vídeo",
+    domain_noun_indefinite="um vídeo",
+    domain_action="analisar",
+    domain_action_present="análise",
+    accepted_extensions=("mp4", "m4v", "mov", "3gp", "3gpp", "webm"),
+    bytes_base64_arg_name="video_bytes_base64",
+    local_path_arg_name="local_video_path",
+    enable_env_var="ENABLE_VIDEO_ADDENDUM",
+    skip_analyze_on_real_user_text=False,  # caption não substitui análise visual+audio
+    type_specific_guidance=_VIDEO_GUIDANCE,
+)
+
+
+MODULE_PROMPT = render_module_prompt(_SPEC)


### PR DESCRIPTION
## Summary

Novo prompt module `video_inbound` instrui o LLM a chamar `analyze_inbound_video` (Gemini multimodal frames + audio) depois de `register_inbound_media` quando o cidadão envia vídeo pelo WhatsApp.

Espelha vision/audio via AnalyzableMediaSpec (ADR-018). Schema da análise inclui `transcricao_audio` (Gemini extrai fala do vídeo se houver).

## Dependências

- MCP PR #64 (`analyze_inbound_video` tool) — **DEPLOY ANTES deste**

## Test plan

- [x] 35/35 prompt module tests passing
- [x] Codex review limpo (2 ciclos)
- [ ] Deploy + E2E real com vídeo do WhatsApp

🤖 Generated with [Claude Code](https://claude.com/claude-code)