### PR TITLE
feat(prompt-modules): audio_response — instrui LLM a gerar áudio TTS

### DIFF
--- a/src/config/env.py
+++ b/src/config/env.py
@@ -39,6 +39,12 @@ MCP_EXCLUDED_TOOLS = (
     else []
 )
 
+# Kill switch coarse pro TTS — desliga prompt module `audio_response` no
+# engine + tool `generate_audio_response` no MCP server. Default-on:
+# valor vazio/ausente OU qualquer != "false" ⇒ habilitado. Tem que
+# espelhar o que o MCP server lê.
+ENABLE_TTS_ADDENDUM = getenv_or_action("ENABLE_TTS_ADDENDUM", default="true")
+
 OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = getenv_or_action(
     "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
 )

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -116,9 +116,21 @@ def deploy(deploy_timestamp=None):
             "EAI_GATEWAY_API_TOKEN": env.EAI_GATEWAY_API_TOKEN,
             "SHORT_MEMORY_TOKEN_LIMIT": env.SHORT_MEMORY_TOKEN_LIMIT,
             "SHORT_MEMORY_TIME_LIMIT": env.SHORT_MEMORY_TIME_LIMIT,
-            "MCP_EXCLUDED_TOOLS": ",".join(env.MCP_EXCLUDED_TOOLS)
-            if env.MCP_EXCLUDED_TOOLS
-            else "",
+            # ENABLE_TTS_ADDENDUM=false força adicionar
+            # generate_audio_response a MCP_EXCLUDED_TOOLS, garantindo que o
+            # tool binder (engine/agent.py) também o filtre — sem isso o LLM
+            # poderia ver a tool schema mesmo com o prompt addendum removido.
+            # Codex P2 2026-05-15.
+            "MCP_EXCLUDED_TOOLS": ",".join(
+                list(env.MCP_EXCLUDED_TOOLS or [])
+                + (
+                    ["generate_audio_response"]
+                    if (env.ENABLE_TTS_ADDENDUM or "true").lower() == "false"
+                    and "generate_audio_response" not in (env.MCP_EXCLUDED_TOOLS or [])
+                    else []
+                )
+            ),
+            "ENABLE_TTS_ADDENDUM": env.ENABLE_TTS_ADDENDUM,
             "ERROR_INTERCEPTOR_URL": env.ERROR_INTERCEPTOR_URL,
             "ERROR_INTERCEPTOR_TOKEN": env.ERROR_INTERCEPTOR_TOKEN,
         },

--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -32,6 +32,7 @@ from typing import Tuple
 
 from src.prompt_modules import (
     audio_inbound,
+    audio_response,
     media_inbound,
     video_inbound,
     vision_inbound,
@@ -52,6 +53,27 @@ from src.prompt_modules import (
 # `[FLOW_COMPLETION]`, próprio dispatcher MCP). Ordenado por último —
 # media_inbound prefix dá precedência em casos ambíguos (improvável mas
 # concebível se um flow_name fizer match com palavra de prefix media).
+# audio_response só entra na lista quando a tool MCP correspondente
+# (`generate_audio_response`) está disponível em runtime. Lê via
+# `getenv_or_action` com `action='ignore'` pra honrar as MESMAS fontes
+# que `src.config.env` (root .env + os.environ) sem fail-fast em testes
+# que não tem deployment vars setadas. Dois sinais desligam:
+#   1. Kill switch coarse: ENABLE_TTS_ADDENDUM=false.
+#   2. Exclusão fina: 'generate_audio_response' em MCP_EXCLUDED_TOOLS.
+# Sem checagens: o LLM seria instruído a chamar tool não-bound e turns
+# explícitos de áudio quebrariam.
+from src.utils.infisical import getenv_or_action as _getenv_or_action
+
+_excluded_tools = {
+    t.strip()
+    for t in (_getenv_or_action("MCP_EXCLUDED_TOOLS", action="ignore", default="") or "").split(",")
+    if t.strip()
+}
+_audio_response_enabled = (
+    (_getenv_or_action("ENABLE_TTS_ADDENDUM", action="ignore", default="true") or "true").lower() != "false"
+    and "generate_audio_response" not in _excluded_tools
+)
+
 ENABLED_MODULES = [
     media_inbound,
     vision_inbound,
@@ -59,6 +81,8 @@ ENABLED_MODULES = [
     video_inbound,
     whatsapp_flow_inbound,
 ]
+if _audio_response_enabled:
+    ENABLED_MODULES.append(audio_response)
 
 
 def compose(base_prompt: str, base_version: str) -> Tuple[str, str]:

--- a/src/prompt_modules/audio_response.py
+++ b/src/prompt_modules/audio_response.py
@@ -1,0 +1,81 @@
+"""
+Prompt module — gera resposta em áudio (TTS) quando o cidadão pede.
+
+Cenário: cidadão envia algo como "responda por áudio", "manda em áudio",
+"prefiro ouvir", "quero a resposta em áudio". O LLM deve detectar essa
+intent e:
+
+1. Compor a resposta normalmente em texto (linguagem que ele falaria).
+2. Chamar a tool MCP ``generate_audio_response(text=<resposta>)``.
+3. Anexar o ``audio_base64`` retornado à resposta final, como campo
+   adicional além do texto (Mule consome via callback).
+
+A preferência por áudio NÃO é persistida automaticamente — cada pedido
+do cidadão por áudio gera uma resposta em áudio APENAS naquele turno.
+Se ele quiser modo contínuo, ele dirá "fica em áudio sempre" e o LLM
+deve continuar gerando áudio até receber "volta pra texto".
+
+Kill switch: ``ENABLE_TTS_ADDENDUM=false`` no MCP env desliga registro
+da tool E o conteúdo deste módulo (o LLM não verá a instrução de
+chamar ``generate_audio_response``).
+"""
+
+MODULE_NAME = "audio_response"
+
+
+MODULE_PROMPT = """\
+## Resposta por áudio (`generate_audio_response`)
+
+Quando o cidadão pedir explicitamente a resposta em áudio (ex: "responda por áudio", "manda áudio", "prefiro ouvir", "quero a resposta em áudio", "vc pode falar?"), siga este protocolo:
+
+1. **Componha a resposta normalmente em texto** — em linguagem natural, como você falaria. Evite emojis, formatação markdown (asteriscos, listas com bullet) e abreviações que ficariam ruins quando faladas em voz alta. Frases curtas (15–25 palavras) e pausas naturais (vírgulas, pontos finais) ficam melhor pra TTS PT-BR.
+
+2. **Chame `generate_audio_response(text=<resposta>)`** depois de compor o texto. A tool retorna `{status, audio_base64, mime_type, duration_estimate_s, voice_used}`.
+
+   - Se `status='ok'`: anexe `audio_base64` na resposta final. O Mule downstream uploada pro Meta e envia como mensagem de voz (PTT) pro cidadão.
+   - Se `status='deferred'` (TTS indisponível, ex: credentials não configuradas): responda só por texto + avise: "(Não consegui gerar áudio agora, segue por texto.)"
+   - Se `status='error'`: mesmo tratamento de `deferred` — responda só texto + breve aviso.
+
+3. **Modo contínuo vs único turno:**
+   - Default: gere áudio APENAS no turno em que o cidadão pediu. Próximo turno volta pra texto.
+   - Se o cidadão explicitar continuidade ("fica em áudio sempre", "continua falando", "não precisa mais escrever"), continue gerando áudio nos próximos turnos até receber sinal contrário ("volta pra texto", "desliga áudio", "escreve aí").
+
+4. **NÃO chame `generate_audio_response` quando:**
+   - Cidadão não pediu (texto é o default).
+   - A resposta é um ack curto (<10 palavras) tipo "Ok!", "Obrigado!", "Tudo certo!" — desperdiça quota TTS pra fala de 1s.
+   - A resposta tem dados estruturados que o cidadão precisa ler (lista de opções numeradas do `multi_step_service`, URLs, números de protocolo). Texto é melhor.
+   - A resposta tem código, comandos ou termos técnicos que TTS pronuncia mal. Texto é melhor.
+
+### Estilo PT-BR pra TTS
+
+A voz default é `pt-BR-Neural2-A` (Google Cloud TTS, feminina, neural). Ela pronuncia bem PT-BR mas ainda assim:
+
+- **Use grafia natural**: "vou te ajudar" em vez de "irei ajudá-lo".
+- **Expanda abreviações**: "às 14h" → "às catorze horas"; "Rua XV de Novembro" → "Rua quinze de Novembro".
+- **Evite gírias visuais**: emojis, "vc", "tbm" — não saem bem em áudio.
+- **Pontuação dá ritmo**: vírgulas curtas, ponto final no fim de cada ideia.
+
+### Exemplo
+
+```
+USER: responda por audio: como abrir um chamado de luminária quebrada?
+
+ASSISTANT (raciocínio): cidadão pediu áudio, vou compor texto natural sem markdown.
+
+ASSISTANT (tool call): generate_audio_response(
+  text="Pra abrir um chamado de luminária quebrada, me passa o endereço completo, com rua, número e bairro. Depois eu confirmo os dados e abro a solicitação no sistema da Prefeitura."
+)
+
+TOOL RETURNS: {"status": "ok", "audio_base64": "T2dnUw...", "mime_type": "audio/ogg", "duration_estimate_s": 9.5, "voice_used": "pt-BR-Neural2-A"}
+
+ASSISTANT (resposta final ao cidadão):
+[áudio anexado via audio_base64]
+"Pra abrir um chamado de luminária quebrada, me passa o endereço completo, com rua, número e bairro. Depois eu confirmo os dados e abro a solicitação no sistema da Prefeitura."
+```
+
+A resposta final inclui o texto (pra logs/audit + cidadão poder ler) E o `audio_base64` em campo separado pro Mule processar.
+
+### REGRA CRÍTICA
+
+O cidadão precisa ter pedido explicitamente. Não infira modo áudio de "pediu rapidez", "tá com pressa", "quer simples" — esses são pedidos por brevidade, não por áudio. Apenas frases explícitas tipo "áudio", "ouvir", "falar" disparam o protocolo.
+"""


### PR DESCRIPTION
## Summary

Novo prompt module `audio_response` que ensina o LLM a chamar `generate_audio_response` MCP tool quando cidadão pede resposta em áudio explicitamente.

## Kill switch (coarse + fine)

Espelha o MCP — duas formas de desligar:
1. `ENABLE_TTS_ADDENDUM=false` (coarse): desliga prompt module + `generate_audio_response` é auto-adicionado a `MCP_EXCLUDED_TOOLS` no deploy
2. `generate_audio_response` em `MCP_EXCLUDED_TOOLS` (fine): prompt module não é registrado

## Componentes

- `src/prompt_modules/audio_response.py` — spec + guidance (estilo PT-BR pra TTS, regras de NÃO chamar)
- `src/prompt_modules/__init__.py` — registro condicional via `getenv_or_action` (compat .env + os.environ, sem fail-fast em testes)
- `src/config/env.py` — carrega `ENABLE_TTS_ADDENDUM`
- `src/deploy.py` — propaga env var + auto-exclude no `MCP_EXCLUDED_TOOLS` quando kill switch off

## Dependências

- MCP PR #65 (`generate_audio_response` tool) — **DEPLOY ANTES deste**

## Test plan

- [x] 35/35 prompt module tests passing
- [x] Codex review 8 ciclos limpo
- [ ] Deploy + E2E real com cidadão pedindo áudio

🤖 Generated with [Claude Code](https://claude.com/claude-code)