### PR TITLE
feat(prompt-modules): media_response prompt module (ADR-022)

### DIFF
--- a/src/config/env.py
+++ b/src/config/env.py
@@ -44,6 +44,10 @@ MCP_EXCLUDED_TOOLS = (
 # valor vazio/ausente OU qualquer != "false" ⇒ habilitado. Tem que
 # espelhar o que o MCP server lê.
 ENABLE_TTS_ADDENDUM = getenv_or_action("ENABLE_TTS_ADDENDUM", default="true")
+# Kill switch pro media response generico (ADR-022) — desliga prompt
+# module `media_response` no engine + tool `send_whatsapp_media` no MCP
+# server. Mesma semantica do ENABLE_TTS_ADDENDUM.
+ENABLE_MEDIA_RESPONSE = getenv_or_action("ENABLE_MEDIA_RESPONSE", default="true")
 
 OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = getenv_or_action(
     "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -120,7 +120,8 @@ def deploy(deploy_timestamp=None):
             # generate_audio_response a MCP_EXCLUDED_TOOLS, garantindo que o
             # tool binder (engine/agent.py) também o filtre — sem isso o LLM
             # poderia ver a tool schema mesmo com o prompt addendum removido.
-            # Codex P2 2026-05-15.
+            # Mesma logica pra ENABLE_MEDIA_RESPONSE=false + send_whatsapp_media
+            # (ADR-022). Codex P2 2026-05-15.
             "MCP_EXCLUDED_TOOLS": ",".join(
                 list(env.MCP_EXCLUDED_TOOLS or [])
                 + (
@@ -129,8 +130,15 @@ def deploy(deploy_timestamp=None):
                     and "generate_audio_response" not in (env.MCP_EXCLUDED_TOOLS or [])
                     else []
                 )
+                + (
+                    ["send_whatsapp_media"]
+                    if (env.ENABLE_MEDIA_RESPONSE or "true").lower() == "false"
+                    and "send_whatsapp_media" not in (env.MCP_EXCLUDED_TOOLS or [])
+                    else []
+                )
             ),
             "ENABLE_TTS_ADDENDUM": env.ENABLE_TTS_ADDENDUM,
+            "ENABLE_MEDIA_RESPONSE": env.ENABLE_MEDIA_RESPONSE,
             "ERROR_INTERCEPTOR_URL": env.ERROR_INTERCEPTOR_URL,
             "ERROR_INTERCEPTOR_TOKEN": env.ERROR_INTERCEPTOR_TOKEN,
         },

--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -34,6 +34,7 @@ from src.prompt_modules import (
     audio_inbound,
     audio_response,
     media_inbound,
+    media_response,
     video_inbound,
     vision_inbound,
     whatsapp_flow_inbound,
@@ -73,6 +74,14 @@ _audio_response_enabled = (
     (_getenv_or_action("ENABLE_TTS_ADDENDUM", action="ignore", default="true") or "true").lower() != "false"
     and "generate_audio_response" not in _excluded_tools
 )
+# `media_response` (ADR-022) gate: registra a instrução pra send_whatsapp_media
+# apenas quando a tool MCP correspondente está bound. Mesma estratégia do
+# audio_response — sem checagens, LLM seria instruído a chamar tool não-bound
+# e turns com pedido de mídia produziriam erro de tool unknown.
+_media_response_enabled = (
+    (_getenv_or_action("ENABLE_MEDIA_RESPONSE", action="ignore", default="true") or "true").lower() != "false"
+    and "send_whatsapp_media" not in _excluded_tools
+)
 
 ENABLED_MODULES = [
     media_inbound,
@@ -83,6 +92,8 @@ ENABLED_MODULES = [
 ]
 if _audio_response_enabled:
     ENABLED_MODULES.append(audio_response)
+if _media_response_enabled:
+    ENABLED_MODULES.append(media_response)
 
 
 def compose(base_prompt: str, base_version: str) -> Tuple[str, str]:

--- a/src/prompt_modules/media_response.py
+++ b/src/prompt_modules/media_response.py
@@ -1,0 +1,92 @@
+"""
+Prompt module — gera resposta em mídia (image/video/document/location/...)
+quando o cidadão pede.
+
+Cenário: cidadão envia algo como "manda em foto", "compartilha a
+localização do posto", "manda o documento em PDF". O LLM deve detectar
+essa intent e:
+
+1. Compor a resposta textual normalmente (linguagem natural).
+2. Chamar a tool MCP ``send_whatsapp_media(type=<tipo>, ...)``.
+3. Anexar o envelope canônico retornado à resposta final (Mule consome
+   via callback `vars.agentMedia` em webhook-flow.xml, ADR-022).
+
+Análogo a ``audio_response.py`` mas pra qualquer tipo de mídia exceto
+áudio (que tem prompt dedicado pra orientação de estilo TTS).
+
+Tipos suportados pelo Mule (ADR-022):
+- ``image``     — foto/captura. Url (Meta busca direto) ou base64 (Mule
+                  faz upload via /media).
+- ``video``     — vídeo curto (Meta limita ~16MB). Url ou base64.
+- ``document``  — PDF, DOCX, XLSX, etc. Url ou base64. Permite filename.
+- ``sticker``   — figurinha WebP animada/estática. Url ou base64.
+- ``location``  — lat/lng + name + address opcionais. Sem upload.
+- ``contacts``  — lista de cards de contato.
+- ``interactive`` — Flow/button/list/product (avançado, usar com
+                    cuidado).
+
+Para áudio, use ``generate_audio_response`` (módulo ``audio_response``)
+que tem estilo TTS dedicado.
+
+Kill switch: ``ENABLE_MEDIA_RESPONSE=false`` no MCP env desliga registro
+da tool E o conteúdo deste módulo (mesmo padrão de audio_response).
+"""
+
+MODULE_NAME = "media_response"
+
+
+MODULE_PROMPT = """\
+## Resposta em mídia (`send_whatsapp_media`)
+
+Quando o cidadão pedir explicitamente uma resposta em formato não-texto (imagem, vídeo, documento, localização, sticker), use `send_whatsapp_media`. Casos típicos:
+
+| Pedido do cidadão | type sugerido | params |
+|---|---|---|
+| "Manda a foto do posto" | `image` | `url` (URL pública da foto) |
+| "Compartilha a localização do posto" | `location` | `latitude`, `longitude`, `name`, `address` |
+| "Manda o protocolo em PDF" | `document` | `url`, `filename` |
+| "Manda um vídeo explicando" | `video` | `url`, `caption` |
+| "Manda uma figurinha de aprovado" | `sticker` | `url` |
+
+**REGRA #1: só responda com mídia se o cidadão pediu explicitamente.** Não infira de "mostra", "quero ver", "prefiro" — esses são pedidos genéricos que se resolvem em texto. Apenas frases tipo "manda a foto", "compartilha a localização", "envia o documento" disparam o protocolo.
+
+**REGRA #2: prefira `url` quando você tem o link de mídia pública.** Meta busca direto, mais rápido. Use `base64` apenas quando você gerou a mídia inline (ex: TTS via outra tool). Se passar `base64`, **sempre passe `mime_type` explícito** (Meta rejeita upload sem MIME consistente — `image/jpeg`, `image/png`, `video/mp4`, `application/pdf`, `image/webp`).
+
+**REGRA #3: nunca passe `url` E `base64` simultaneamente.** Mutuamente exclusivos — tool rejeita.
+
+**REGRA #4: location precisa de coordenadas reais.** Não invente lat/lng — use os retornos das tools de equipamentos (`equipments_query`, `find_unidade_de_saude_proxima`, etc.) que retornam lat/lng dos equipamentos públicos. Se você só tem endereço, use a tool `validate_address` primeiro pra geocodar.
+
+### Exemplo end-to-end
+
+```
+USER: compartilha a localização do posto de saúde mais próximo de mim. Estou na rua Paissandu 165.
+
+ASSISTANT (tool call 1): validate_address(address="rua Paissandu 165")
+TOOL RETURNS: {"lat": -22.93, "lng": -43.18, "neighborhood": "Flamengo"}
+
+ASSISTANT (tool call 2): find_unidade_de_saude_proxima(lat=-22.93, lng=-43.18)
+TOOL RETURNS: {"name": "CMS Flamengo", "lat": -22.94, "lng": -43.17, "address": "Rua Marquês de Abrantes 95"}
+
+ASSISTANT (tool call 3): send_whatsapp_media(
+  type="location",
+  latitude=-22.94, longitude=-43.17,
+  name="CMS Flamengo",
+  address="Rua Marquês de Abrantes 95"
+)
+TOOL RETURNS: {"status": "ok", "type": "location", ...}
+
+ASSISTANT (texto AO CIDADÃO):
+Compartilhei a localização do CMS Flamengo (Rua Marquês de Abrantes 95). Aberto seg-sex 7h-17h.
+```
+
+### Quando NÃO chamar `send_whatsapp_media`
+
+- Cidadão não pediu mídia explicitamente (texto é o default).
+- Você não tem URL pública nem base64 da mídia. Inventar URL inválida quebra a entrega — Mule cai pra texto e o cidadão vê apenas a resposta textual.
+- Para áudio: use `generate_audio_response` (módulo dedicado, ADR-021).
+- Para flows interativos (formulários): use `multi_step_service` que orquestra o ciclo Flow → coleta → confirmação. NÃO chame `send_whatsapp_media(type="interactive")` direto a menos que orientado.
+
+### REGRA CRÍTICA
+
+O cidadão precisa pedir mídia explicitamente. Não responda com `image`/`document`/`location` proativamente — pode confundir cidadão que esperava texto.
+"""


### PR DESCRIPTION
## Summary

Adiciona prompt module `media_response` orientando o LLM a chamar `send_whatsapp_media` (tool MCP, ADR-022) quando o cidadão pede explicitamente resposta em formato não-texto (image/video/document/location/sticker/contacts/interactive).

Análogo ao `audio_response` (ADR-021) — gated por env var (`ENABLE_MEDIA_RESPONSE`) + presença da tool MCP correspondente.

## Cross-repo deps

- [study-sf-whatsapp-poc1 PR #14](https://github.com/prefeitura-rio/study-sf-whatsapp-poc1/pull/14) (Mule send-via-meta-media-flow) ✅ merged
- [app-mcp-server PR #66](https://github.com/prefeitura-rio/app-mcp-server/pull/66) (send_whatsapp_media tool) auto-merge pending

## ADR

[ADR-022](https://github.com/prefeitura-rio/study-sf-whatsapp-poc1/blob/main/docs/decisoes/022-outbound-media-genericco-data-driven.md)

## Test plan

- [x] 35/35 unit tests passing
- [x] Composição do prompt valida (7 modules incluindo media_response)
- [x] Codex review limpo
- [ ] Manual: smoke test E2E após app-mcp-server PR #66 merge (tool disponível)

🤖 Generated with [Claude Code](https://claude.com/claude-code)