### PR TITLE
feat(prompt-modules): interactive_response (ADR-024 + ADR-022)

### DIFF
--- a/src/config/env.py
+++ b/src/config/env.py
@@ -48,6 +48,12 @@ ENABLE_TTS_ADDENDUM = getenv_or_action("ENABLE_TTS_ADDENDUM", default="true")
 # module `media_response` no engine + tool `send_whatsapp_media` no MCP
 # server. Mesma semantica do ENABLE_TTS_ADDENDUM.
 ENABLE_MEDIA_RESPONSE = getenv_or_action("ENABLE_MEDIA_RESPONSE", default="true")
+# Kill switch pro interactive response (ADR-024 + ADR-022) — desliga
+# prompt module `interactive_response` + tools send_whatsapp_flow/
+# _buttons/_list no MCP server.
+ENABLE_INTERACTIVE_RESPONSE = getenv_or_action(
+    "ENABLE_INTERACTIVE_RESPONSE", default="true"
+)
 
 OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = getenv_or_action(
     "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -136,9 +136,15 @@ def deploy(deploy_timestamp=None):
                     and "send_whatsapp_media" not in (env.MCP_EXCLUDED_TOOLS or [])
                     else []
                 )
+                + (
+                    ["send_whatsapp_flow", "send_whatsapp_buttons", "send_whatsapp_list"]
+                    if (env.ENABLE_INTERACTIVE_RESPONSE or "true").lower() == "false"
+                    else []
+                )
             ),
             "ENABLE_TTS_ADDENDUM": env.ENABLE_TTS_ADDENDUM,
             "ENABLE_MEDIA_RESPONSE": env.ENABLE_MEDIA_RESPONSE,
+            "ENABLE_INTERACTIVE_RESPONSE": env.ENABLE_INTERACTIVE_RESPONSE,
             "ERROR_INTERCEPTOR_URL": env.ERROR_INTERCEPTOR_URL,
             "ERROR_INTERCEPTOR_TOKEN": env.ERROR_INTERCEPTOR_TOKEN,
         },

--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -33,6 +33,7 @@ from typing import Tuple
 from src.prompt_modules import (
     audio_inbound,
     audio_response,
+    interactive_response,
     media_inbound,
     media_response,
     video_inbound,
@@ -82,6 +83,16 @@ _media_response_enabled = (
     (_getenv_or_action("ENABLE_MEDIA_RESPONSE", action="ignore", default="true") or "true").lower() != "false"
     and "send_whatsapp_media" not in _excluded_tools
 )
+# `interactive_response` (ADR-024) gate: registra instruções pros tools
+# send_whatsapp_flow/_buttons/_list. Mesma estratégia: precisam estar bound.
+_interactive_response_enabled = (
+    (_getenv_or_action("ENABLE_INTERACTIVE_RESPONSE", action="ignore", default="true") or "true").lower() != "false"
+    and not (
+        "send_whatsapp_flow" in _excluded_tools
+        and "send_whatsapp_buttons" in _excluded_tools
+        and "send_whatsapp_list" in _excluded_tools
+    )
+)
 
 ENABLED_MODULES = [
     media_inbound,
@@ -94,6 +105,8 @@ if _audio_response_enabled:
     ENABLED_MODULES.append(audio_response)
 if _media_response_enabled:
     ENABLED_MODULES.append(media_response)
+if _interactive_response_enabled:
+    ENABLED_MODULES.append(interactive_response)
 
 
 def compose(base_prompt: str, base_version: str) -> Tuple[str, str]:

--- a/src/prompt_modules/interactive_response.py
+++ b/src/prompt_modules/interactive_response.py
@@ -1,0 +1,108 @@
+"""
+Prompt module — orienta LLM a usar os tools de interactive Meta
+(`send_whatsapp_flow`, `send_whatsapp_buttons`, `send_whatsapp_list`)
+em vez de listar opções em texto plain.
+
+Análogo a ``media_response`` (ADR-022) mas pra tipos interativos.
+Esses tools constroem o objeto Meta `interactive` (Flow/button/list)
+e retornam o envelope canônico que o Mule consome via vars.agentMedia.
+
+Kill switch: ``ENABLE_INTERACTIVE_RESPONSE=false`` desliga registro
+da tool E o conteúdo deste módulo.
+"""
+
+MODULE_NAME = "interactive_response"
+
+MODULE_PROMPT = """\
+## Resposta interativa (`send_whatsapp_flow` / `_buttons` / `_list`)
+
+Quando o cidadão precisa escolher entre opções discretas, **prefira mensagens interativas** ao texto puro. WhatsApp renderiza nativamente botões e listas, melhorando UX vs. cidadão digitar "opção 1" ou "Iluminação Pública".
+
+### Matriz de escolha
+
+| Caso | Tool | Quando usar |
+|---|---|---|
+| Coleta estruturada de campos (formulário) | `send_whatsapp_flow` | Cidadão precisa preencher múltiplos campos (endereço + defeito + foto). Use somente se há Flow registrado no Meta Business Manager pro service. |
+| 2-3 opções (Sim/Não/Outro) | `send_whatsapp_buttons` | Confirmação binária+1, escolha de canal de contato, "Quer abrir chamado?". |
+| 4-10 opções organizadas | `send_whatsapp_list` | Menu de serviços, lista de bairros, tipos de chamado. Acima de 3 opções, buttons lota a tela. |
+| Mais de 10 opções | Não usar interactive. Pedir busca textual ("Digite o bairro:"). |
+| Resposta livre / texto explicativo | Texto normal | Default. Use quando há contexto a transmitir, não escolha. |
+
+### Exemplo: send_whatsapp_buttons
+
+```
+USER: oi, queria reportar um problema na rua
+
+ASSISTANT (tool call): send_whatsapp_buttons(
+  body="O que você quer reportar?",
+  buttons=[
+    {"id": "luminaria", "title": "Luminária"},
+    {"id": "buraco", "title": "Buraco na rua"},
+    {"id": "outros", "title": "Outro"}
+  ]
+)
+
+TOOL RETURNS: {"status": "ok", "type": "interactive", "interactive": {...}}
+
+(Cidadão clica botão → bot recebe inbound com interactive.button_reply.id="luminaria")
+```
+
+### Exemplo: send_whatsapp_list
+
+```
+USER: queria abrir um chamado
+
+ASSISTANT (tool call): send_whatsapp_list(
+  body="Sobre qual serviço?",
+  sections=[
+    {
+      "title": "Iluminação",
+      "rows": [
+        {"id": "luminaria_quebrada", "title": "Luminária quebrada"},
+        {"id": "poste_caido", "title": "Poste caído"}
+      ]
+    },
+    {
+      "title": "Limpeza Urbana",
+      "rows": [
+        {"id": "coleta_irregular", "title": "Coleta irregular"},
+        {"id": "entulho", "title": "Entulho na rua"}
+      ]
+    }
+  ]
+)
+```
+
+### Exemplo: send_whatsapp_flow
+
+```
+USER: minha luminaria quebrou
+
+ASSISTANT: identifica que é caso de reparo_luminaria → tem Flow registrado.
+ASSISTANT (tool call): send_whatsapp_flow(
+  flow_id="4141008006029185",
+  body="Vou abrir o chamado pra você. Preencha o formulário abaixo:",
+  flow_token=<UUID gerado>,
+  cta="Preencher"
+)
+
+(Cidadão preenche → bot recebe inbound com interactive.nfm_reply.response_json)
+```
+
+### REGRA CRÍTICA
+
+- **NUNCA** liste opções numeradas em texto ("1. Luminária 2. Buraco 3. Outro") quando você tem `send_whatsapp_buttons` ou `send_whatsapp_list` disponível. UX visual é sempre melhor.
+- **NUNCA** chame Flow proativamente — só quando o cidadão indicou intent compatível com algum service registrado. Se não tem Flow, use list.
+- **flow_token sempre único por turno** — gere UUID novo a cada `send_whatsapp_flow`. Reutilizar token confunde o tracking de submissões.
+- **Caption livre no body** — use `body` pra contextualizar, não pra duplicar o texto dos botões/rows. Cidadão vê body + lista; redundância polui.
+
+### Como o cidadão responde
+
+| Tool out | Inbound shape |
+|---|---|
+| send_whatsapp_buttons | `message_type=interactive` com `interactive.button_reply.id` = `id` que você setou |
+| send_whatsapp_list | `message_type=interactive` com `interactive.list_reply.id` = `id` da row escolhida |
+| send_whatsapp_flow | `message_type=interactive` com `interactive.nfm_reply.response_json` = JSON dos campos preenchidos. Vai pra `whatsapp_flow_inbound` protocolo (ADR-024). |
+
+O LLM decide o próximo passo baseado no `id` retornado — geralmente avança o workflow ou abre o próximo Flow.
+"""


### PR DESCRIPTION
## Summary

Prompt module novo orientando LLM a usar `send_whatsapp_flow`, `send_whatsapp_buttons`, `send_whatsapp_list` (MCP tools de PR #69) em vez de listar opções em texto.

## Cross-repo deps

- [app-mcp-server PR #69](https://github.com/prefeitura-rio/app-mcp-server/pull/69) (3 tools interactive) — auto-merge pending

## Test plan

- [x] 35/35 unit tests passing
- [x] Composição prompt valida (8 modules)
- [ ] Manual: smoke test após PR #69 merged + tools bound em runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)