### PR TITLE
perf(engine): thinking_budget + include_thoughts + temperature via env vars

### DIFF
--- a/src/config/env.py
+++ b/src/config/env.py
@@ -55,6 +55,26 @@ ENABLE_INTERACTIVE_RESPONSE = getenv_or_action(
     "ENABLE_INTERACTIVE_RESPONSE", default="true"
 )
 
+# === LLM tuning (latency vs quality trade-offs) ===
+# THINKING_BUDGET: tokens maximos que o Gemini 2.5 Flash pode gastar em
+# chain-of-thought antes de responder. Default -1 (unbounded) mantem
+# comportamento atual. Limites menores (e.g. 1024-4096) reduzem latencia
+# 5-15s/turn mas podem afetar qualidade em queries complexas. Testar com
+# eval suite antes de promover.
+THINKING_BUDGET = int(getenv_or_action("THINKING_BUDGET", default="-1") or "-1")
+# INCLUDE_THOUGHTS: se o LLM retorna o texto de chain-of-thought no
+# response (alem da resposta final). Default true mantem traces visiveis
+# em logs/OTel pra debug. Setar false reduz payload de saida mas nao
+# afeta latencia de inferencia significativamente.
+INCLUDE_THOUGHTS = (
+    (getenv_or_action("INCLUDE_THOUGHTS", default="true") or "true").lower() != "false"
+)
+# LLM_TEMPERATURE: criatividade do LLM. Default 0.7 (atual). Valores
+# menores (e.g. 0.3) sao mais deterministicos + ligeiramente mais rapidos.
+LLM_TEMPERATURE = float(
+    getenv_or_action("LLM_TEMPERATURE", default="0.7") or "0.7"
+)
+
 OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = getenv_or_action(
     "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
 )

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -27,12 +27,15 @@ def deploy(deploy_timestamp=None):
 
     # Tools will be loaded at runtime from MCP server (not at deployment time)
     # This allows deployment from local machine where MCP private network is not accessible
+    # LLM tuning vem de env vars com defaults preservando comportamento atual.
+    # Set THINKING_BUDGET=4096 (ou similar) pra reduzir latencia em queries
+    # complexas — testar com eval suite antes de promover pra producao.
     local_agent = Agent(
         model=model,
         system_prompt=system_prompt,
-        include_thoughts=True,
-        thinking_budget=-1,  # 0 to disable, -1 to unlimited and other token limit value
-        temperature=0.7,
+        include_thoughts=env.INCLUDE_THOUGHTS,
+        thinking_budget=env.THINKING_BUDGET,  # 0 to disable, -1 unlimited, N pra cap
+        temperature=env.LLM_TEMPERATURE,
         tools=[],  # Empty - tools loaded lazily at runtime
         otpl_service=f"eai-langgraph-v{system_prompt_version}",
     )
@@ -145,6 +148,11 @@ def deploy(deploy_timestamp=None):
             "ENABLE_TTS_ADDENDUM": env.ENABLE_TTS_ADDENDUM,
             "ENABLE_MEDIA_RESPONSE": env.ENABLE_MEDIA_RESPONSE,
             "ENABLE_INTERACTIVE_RESPONSE": env.ENABLE_INTERACTIVE_RESPONSE,
+            # LLM tuning (preserved at deploy time + propagated as env vars
+            # so eventuais consumidores runtime tambem leem o mesmo valor)
+            "THINKING_BUDGET": str(env.THINKING_BUDGET),
+            "INCLUDE_THOUGHTS": "true" if env.INCLUDE_THOUGHTS else "false",
+            "LLM_TEMPERATURE": str(env.LLM_TEMPERATURE),
             "ERROR_INTERCEPTOR_URL": env.ERROR_INTERCEPTOR_URL,
             "ERROR_INTERCEPTOR_TOKEN": env.ERROR_INTERCEPTOR_TOKEN,
         },


### PR DESCRIPTION
## Summary

Torna 3 parâmetros do Agent LLM configuráveis via env vars — defaults preservam comportamento atual:

- **`THINKING_BUDGET`** (default `-1` = unbounded) — tokens máximos de chain-of-thought antes de responder. Limites menores (e.g. `4096`) podem reduzir latência **5-15s/turn** em queries complexas. Risco: qualidade em casos edge.
- **`INCLUDE_THOUGHTS`** (default `true`) — se LLM retorna texto de raciocínio no response. False = payload menor.
- **`LLM_TEMPERATURE`** (default `0.7`) — criatividade.

Permite operador testar trade-offs latency vs quality sem mudança de código.

## Como usar

1. Setar `THINKING_BUDGET=4096` (ou outro) em Infisical staging
2. Deploy via `/deploy staging`
3. Aguardar `Evals After Deploy` (workflow guard pra produção)
4. Se eval pass: `/deploy production`

## Test plan

- [x] 35/35 unit tests passing
- [x] Defaults preservam comportamento atual (-1 / true / 0.7)
- [x] Pattern segue ENABLE_TTS_ADDENDUM/ENABLE_MEDIA_RESPONSE/ENABLE_INTERACTIVE_RESPONSE já em produção

🤖 Generated with [Claude Code](https://claude.com/claude-code)