### PR TITLE
feat(prompt-modules): workflow_continuation evita ack-only mid-multi_step_service

### DIFF
--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -38,6 +38,7 @@ from src.prompt_modules import (
     media_response,
     video_inbound,
     vision_inbound,
+    workflow_continuation,
     whatsapp_flow_inbound,
 )
 
@@ -95,6 +96,7 @@ _interactive_response_enabled = (
 )
 
 ENABLED_MODULES = [
+    workflow_continuation,
     media_inbound,
     vision_inbound,
     audio_inbound,

--- a/src/prompt_modules/audio_inbound.py
+++ b/src/prompt_modules/audio_inbound.py
@@ -61,6 +61,20 @@ Use `analysis.workflow_sugerido` pra decidir:
 - `nenhum` → use `analysis.transcricao` como mensagem real do cidadão e
   continue o fluxo normal.
 
+### Áudio como resposta a etapa de workflow ativo
+
+Se já existe um workflow ativo aguardando um campo, trate
+`analysis.transcricao` como a resposta do cidadão para essa etapa antes de
+responder em texto. Não encerre com apenas um acknowledgement.
+
+Caso crítico observado em produção: se o workflow ativo pediu CPF e a
+transcrição indicar recusa de identificação ("não quero me identificar",
+"continuar sem CPF", "prefiro não informar CPF", "anônimo"), chame
+`multi_step_service` no workflow ativo com payload marcando CPF ausente/recusado
+(ex.: `cpf=null`, `identificacao_recusada=true` ou campo equivalente do
+workflow) e use o retorno da tool para continuar. Não responda apenas
+"vou seguir sem CPF" sem chamar a tool.
+
 ### REGRA: não pedir pro cidadão repetir o áudio em texto
 
 `analysis.transcricao` é a mensagem real do cidadão — você acabou de

--- a/src/prompt_modules/workflow_continuation.py
+++ b/src/prompt_modules/workflow_continuation.py
@@ -1,0 +1,27 @@
+"""
+Modulo de prompt: regras para continuar workflows ja iniciados por
+``multi_step_service``.
+
+Estas instrucoes precisam viver em prompt module ativo porque o prompt base vem
+da API em runtime; editar apenas snapshots comentados em ``src/prompt.py`` nao
+altera o comportamento do agente implantado.
+"""
+
+MODULE_NAME = "workflow_continuation"
+
+MODULE_PROMPT = """\
+## Continuação de workflow ativo (`multi_step_service`)
+
+Quando o historico mostra que um workflow de `multi_step_service` ja esta ativo
+e aguardando um campo, trate a nova mensagem do cidadao como resposta para esse
+campo. Essa resposta NAO e uma nova intencao vaga.
+
+Antes de responder em texto, chame `multi_step_service` no workflow ativo com o
+valor recebido e use o retorno da ferramenta para compor a resposta ao cidadao.
+
+Caso critico: se a etapa pediu CPF e o cidadao disser "continuar sem CPF",
+"nao quero me identificar", "prefiro nao informar CPF", "anonimo" ou variacao
+equivalente, continue o workflow marcando CPF ausente/recusado (ex.:
+`cpf=null`, `identificacao_recusada=true` ou campo equivalente esperado pelo
+workflow). Nao responda apenas "vou seguir sem CPF" sem chamar a tool.
+"""

--- a/tests/unit/test_prompt_modules.py
+++ b/tests/unit/test_prompt_modules.py
@@ -9,7 +9,12 @@ tests pós-deploy em staging.
 """
 
 from src.prompt_modules import compose, ENABLED_MODULES
-from src.prompt_modules import audio_inbound, media_inbound, vision_inbound
+from src.prompt_modules import (
+    audio_inbound,
+    media_inbound,
+    vision_inbound,
+    workflow_continuation,
+)
 
 
 # ---------- compose() — comportamento básico ----------
@@ -341,6 +346,36 @@ def test_audio_inbound_prompt_short_circuits_address_when_available():
     p = audio_inbound.MODULE_PROMPT
     assert "validate_address" in p, "Atalho via validate_address não documentado"
     assert "endereco_mencionado" in p, "Field do atalho não referenciado"
+
+
+def test_audio_inbound_prompt_continues_active_workflow_on_cpf_refusal():
+    """Quando áudio responde a uma etapa ativa, especialmente recusa de CPF,
+    prompt deve mandar continuar via multi_step_service em vez de só dar ack."""
+    p = audio_inbound.MODULE_PROMPT.lower()
+    assert "workflow ativo" in p, "Regra de continuação de workflow ativo ausente"
+    assert "cpf" in p, "Recusa de CPF não documentada"
+    assert "não quero me identificar" in p, "Exemplo de recusa por áudio ausente"
+    assert "multi_step_service" in p, "Continuação via tool não documentada"
+    assert "sem chamar a tool" in p, "Regra anti-ack-only ausente"
+
+
+def test_workflow_continuation_module_is_enabled_before_media_modules():
+    """Regra geral de continuar workflow ativo deve entrar no prompt composto,
+    antes dos modulos de midia que podem produzir respostas de etapa."""
+    names = [m.MODULE_NAME for m in ENABLED_MODULES]
+    assert "workflow_continuation" in names
+    assert names.index("workflow_continuation") < names.index("media_inbound")
+
+
+def test_workflow_continuation_prompt_handles_cpf_refusal():
+    """Recusa de CPF por texto deve continuar workflow ativo via tool."""
+    p = workflow_continuation.MODULE_PROMPT.lower()
+    assert "workflow ativo" in p
+    assert "continuar sem cpf" in p
+    assert "nao quero me identificar" in p
+    assert "cpf ausente/recusado" in p
+    assert "multi_step_service" in p
+    assert "sem chamar a tool" in p
 
 
 # ---------- regressão: idempotência de chamada ----------


### PR DESCRIPTION
## Summary

Bug em produção 2026-05-18: cidadão em workflow `multi_step_service` ativo (poda_de_arvore aguardando CPF) enviou áudio "Não quero me identificar". Agente respondeu "Ouvi seu áudio: você não quer se identificar. Okay, vou seguir sem o seu CPF." e **parou** sem chamar `multi_step_service` para avançar o workflow com `cpf=null`. Cidadão ficou travado.

## Fix

- Novo módulo `prompt_modules.workflow_continuation` cobrindo texto+áudio: quando há workflow ativo, mensagem do cidadão é resposta de etapa (não nova intenção vaga), e o agente deve chamar a tool antes de responder em texto.
- `audio_inbound` ganha seção "Áudio como resposta a etapa de workflow ativo" reforçando o mesmo princípio.
- `workflow_continuation` entra primeiro em `ENABLED_MODULES` (antes de `media_inbound`) — regras gerais antes das específicas por tipo.

## Test plan

- [x] 3 testes novos passam (38 total)
- [ ] /deploy staging → testar com áudio real "não quero me identificar" em workflow ativo
- [ ] Confirmar bot chama `multi_step_service` com `cpf=null` e responde com próximo passo

🤖 Generated with [Claude Code](https://claude.com/claude-code)