### PR TITLE
fix(prompt+gate): alinha interactive_response com rename MCP send_whatsapp_flow→build_whatsapp_flow_envelope

### DIFF
--- a/src/deploy.py
+++ b/src/deploy.py
@@ -140,8 +140,40 @@ def deploy(deploy_timestamp=None):
                     else []
                 )
                 + (
-                    ["send_whatsapp_flow", "send_whatsapp_buttons", "send_whatsapp_list"]
+                    # MCP server renomeou send_whatsapp_flow (low-level) pra
+                    # build_whatsapp_flow_envelope em 2026-05-18. Kill switch
+                    # ENABLE_INTERACTIVE_RESPONSE=false desliga as 3 tools que
+                    # o prompt module orienta (build_whatsapp_flow_envelope +
+                    # send_whatsapp_buttons + send_whatsapp_list).
+                    [
+                        "build_whatsapp_flow_envelope",
+                        "send_whatsapp_buttons",
+                        "send_whatsapp_list",
+                    ]
                     if (env.ENABLE_INTERACTIVE_RESPONSE or "true").lower() == "false"
+                    else []
+                )
+                + (
+                    # `send_whatsapp_flow` high-level (user_number, service_type)
+                    # — sempre excluído enquanto não houver injeção determinística
+                    # de user_number no Engine framework. Sem isso o LLM pode
+                    # invocar com número hallucinado e mandar Flow pra cidadão
+                    # errado. Reativar quando MCP/Engine tiver propagação segura
+                    # (ex: HTTP header X-User-Number derivado de thread_id).
+                    ["send_whatsapp_flow"]
+                    if "send_whatsapp_flow" not in (env.MCP_EXCLUDED_TOOLS or [])
+                    else []
+                )
+                + (
+                    # Migration alias: deployments que ainda têm
+                    # MCP_EXCLUDED_TOOLS contendo `send_whatsapp_flow` (nome
+                    # antigo do low-level) devem também excluir o nome novo
+                    # `build_whatsapp_flow_envelope` — senão a tool low-level
+                    # ficaria bound silenciosamente pós-rename. Mapping
+                    # garante backward-compat.
+                    ["build_whatsapp_flow_envelope"]
+                    if "send_whatsapp_flow" in (env.MCP_EXCLUDED_TOOLS or [])
+                    and "build_whatsapp_flow_envelope" not in (env.MCP_EXCLUDED_TOOLS or [])
                     else []
                 )
             ),

--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -85,11 +85,23 @@ _media_response_enabled = (
     and "send_whatsapp_media" not in _excluded_tools
 )
 # `interactive_response` (ADR-024) gate: registra instruções pros tools
-# send_whatsapp_flow/_buttons/_list. Mesma estratégia: precisam estar bound.
+# build_whatsapp_flow_envelope/send_whatsapp_buttons/send_whatsapp_list.
+# (MCP server renomeou em 2026-05-18 a versão low-level pra
+# build_whatsapp_flow_envelope; o nome send_whatsapp_flow agora é da
+# variante high-level que requer user_number — não usada por este prompt.)
+# Módulo é desabilitado quando o kill-switch ENABLE_INTERACTIVE_RESPONSE
+# vira "false" OU todas as 3 tools que ele orienta estão bloqueadas em
+# MCP_EXCLUDED_TOOLS. Pra migration compat, aceita `send_whatsapp_flow`
+# como alias do antigo nome low-level (deployments preexistentes que
+# excluíam o nome antigo continuam desativando o módulo como esperado).
+_flow_builder_blocked = (
+    "build_whatsapp_flow_envelope" in _excluded_tools
+    or "send_whatsapp_flow" in _excluded_tools  # legacy alias do low-level
+)
 _interactive_response_enabled = (
     (_getenv_or_action("ENABLE_INTERACTIVE_RESPONSE", action="ignore", default="true") or "true").lower() != "false"
     and not (
-        "send_whatsapp_flow" in _excluded_tools
+        _flow_builder_blocked
         and "send_whatsapp_buttons" in _excluded_tools
         and "send_whatsapp_list" in _excluded_tools
     )

--- a/src/prompt_modules/interactive_response.py
+++ b/src/prompt_modules/interactive_response.py
@@ -1,6 +1,6 @@
 """
 Prompt module — orienta LLM a usar os tools de interactive Meta
-(`send_whatsapp_flow`, `send_whatsapp_buttons`, `send_whatsapp_list`)
+(`build_whatsapp_flow_envelope`, `send_whatsapp_buttons`, `send_whatsapp_list`)
 em vez de listar opções em texto plain.
 
 Análogo a ``media_response`` (ADR-022) mas pra tipos interativos.
@@ -14,7 +14,7 @@ da tool E o conteúdo deste módulo.
 MODULE_NAME = "interactive_response"
 
 MODULE_PROMPT = """\
-## Resposta interativa (`send_whatsapp_flow` / `_buttons` / `_list`)
+## Resposta interativa (`build_whatsapp_flow_envelope` / `send_whatsapp_buttons` / `send_whatsapp_list`)
 
 Quando o cidadão precisa escolher entre opções discretas, **prefira mensagens interativas** ao texto puro. WhatsApp renderiza nativamente botões e listas, melhorando UX vs. cidadão digitar "opção 1" ou "Iluminação Pública".
 
@@ -22,7 +22,7 @@ Quando o cidadão precisa escolher entre opções discretas, **prefira mensagens
 
 | Caso | Tool | Quando usar |
 |---|---|---|
-| Coleta estruturada de campos (formulário) | `send_whatsapp_flow` | Cidadão precisa preencher múltiplos campos (endereço + defeito + foto). Use somente se há Flow registrado no Meta Business Manager pro service. |
+| Coleta estruturada de campos (formulário) | `build_whatsapp_flow_envelope` | Cidadão precisa preencher múltiplos campos (endereço + defeito + foto). Use somente se há Flow registrado no Meta Business Manager pro service. |
 | 2-3 opções (Sim/Não/Outro) | `send_whatsapp_buttons` | Confirmação binária+1, escolha de canal de contato, "Quer abrir chamado?". |
 | 4-10 opções organizadas | `send_whatsapp_list` | Menu de serviços, lista de bairros, tipos de chamado. Acima de 3 opções, buttons lota a tela. |
 | Mais de 10 opções | Não usar interactive. Pedir busca textual ("Digite o bairro:"). |
@@ -73,13 +73,15 @@ ASSISTANT (tool call): send_whatsapp_list(
 )
 ```
 
-### Exemplo: send_whatsapp_flow
+### Exemplo: build_whatsapp_flow_envelope
+
+A tool low-level `build_whatsapp_flow_envelope` constrói o envelope WhatsApp Flow com parâmetros manuais (`flow_id` do Meta Business Manager, `body`, `flow_token` UUID, `cta` opcional). Não requer `user_number` — o Mule entrega o envelope retornado ao mesmo cidadão do thread atual.
 
 ```
 USER: minha luminaria quebrou
 
 ASSISTANT: identifica que é caso de reparo_luminaria → tem Flow registrado.
-ASSISTANT (tool call): send_whatsapp_flow(
+ASSISTANT (tool call): build_whatsapp_flow_envelope(
   flow_id="4141008006029185",
   body="Vou abrir o chamado pra você. Preencha o formulário abaixo:",
   flow_token=<UUID gerado>,
@@ -89,11 +91,14 @@ ASSISTANT (tool call): send_whatsapp_flow(
 (Cidadão preenche → bot recebe inbound com interactive.nfm_reply.response_json)
 ```
 
+**Nota sobre `send_whatsapp_flow` (high-level):** existe também a tool `send_whatsapp_flow(user_number, service_type)` que dispara um Flow do registry interno do MCP por nome de serviço. **NÃO chame essa tool a partir deste prompt module** — ela requer `user_number` E.164 que o LLM não tem acesso confiável (a propagação determinística não está wired ainda no Engine framework). Use `build_whatsapp_flow_envelope` quando o agente precisa proativamente abrir Flow. O caminho via `multi_step_service` (que tem `user_id` resolvido no contexto) continua sendo o canal preferido pra workflows estruturados.
+
 ### REGRA CRÍTICA
 
 - **NUNCA** liste opções numeradas em texto ("1. Luminária 2. Buraco 3. Outro") quando você tem `send_whatsapp_buttons` ou `send_whatsapp_list` disponível. UX visual é sempre melhor.
 - **NUNCA** chame Flow proativamente — só quando o cidadão indicou intent compatível com algum service registrado. Se não tem Flow, use list.
-- **flow_token sempre único por turno** — gere UUID novo a cada `send_whatsapp_flow`. Reutilizar token confunde o tracking de submissões.
+- **flow_token sempre único por turno** — gere UUID novo a cada `build_whatsapp_flow_envelope`. Reutilizar token confunde o tracking de submissões.
+- **NÃO chame `send_whatsapp_flow(user_number, service_type)` neste prompt** — risco de hallucination de número. Veja nota acima.
 - **Caption livre no body** — use `body` pra contextualizar, não pra duplicar o texto dos botões/rows. Cidadão vê body + lista; redundância polui.
 
 ### Como o cidadão responde
@@ -102,7 +107,7 @@ ASSISTANT (tool call): send_whatsapp_flow(
 |---|---|
 | send_whatsapp_buttons | `message_type=interactive` com `interactive.button_reply.id` = `id` que você setou |
 | send_whatsapp_list | `message_type=interactive` com `interactive.list_reply.id` = `id` da row escolhida |
-| send_whatsapp_flow | `message_type=interactive` com `interactive.nfm_reply.response_json` = JSON dos campos preenchidos. Vai pra `whatsapp_flow_inbound` protocolo (ADR-024). |
+| build_whatsapp_flow_envelope | `message_type=interactive` com `interactive.nfm_reply.response_json` = JSON dos campos preenchidos. Vai pra `whatsapp_flow_inbound` protocolo (ADR-024). |
 
 O LLM decide o próximo passo baseado no `id` retornado — geralmente avança o workflow ou abre o próximo Flow.
 """

--- a/src/tools.py
+++ b/src/tools.py
@@ -63,4 +63,29 @@ async def get_mcp_tools(
 
     return filtered_tools
 
-mcp_tools = asyncio.run(get_mcp_tools(exclude_tools=env.MCP_EXCLUDED_TOOLS))
+# Safety exclusions aplicadas no loader compartilhado — afeta todos os
+# caminhos (deploy, interactive_test, pre_deploy tests). Mantém estes
+# nomes fora do tool binding mesmo se o operator não os listou em
+# MCP_EXCLUDED_TOOLS.
+#
+# `send_whatsapp_flow` (high-level pós-rename MCP 2026-05-18): requer
+# `user_number` E.164 que o Engine framework não injeta deterministicamente
+# (langgraph-prebuilt 1.0.7 não tem inject_tool_args). LLM pode hallucinar
+# número e mandar Flow pra cidadão errado. Bloqueado até injeção segura
+# estar wired (ex: HTTP header X-User-Number derivado de thread_id).
+#
+# Migration alias: deployments preexistentes que tinham `send_whatsapp_flow`
+# (nome antigo do low-level) em MCP_EXCLUDED_TOOLS devem manter a low-level
+# bloqueada pós-rename — automaticamente também excluímos
+# `build_whatsapp_flow_envelope`.
+_SAFETY_EXCLUDED = ["send_whatsapp_flow"]
+_legacy_excluded = list(env.MCP_EXCLUDED_TOOLS or [])
+if (
+    "send_whatsapp_flow" in _legacy_excluded
+    and "build_whatsapp_flow_envelope" not in _legacy_excluded
+):
+    _SAFETY_EXCLUDED.append("build_whatsapp_flow_envelope")
+
+_effective_excluded = sorted(set(_legacy_excluded) | set(_SAFETY_EXCLUDED))
+
+mcp_tools = asyncio.run(get_mcp_tools(exclude_tools=_effective_excluded))


### PR DESCRIPTION
## Summary

MCP server renomeou em 2026-05-18 a tool low-level `send_whatsapp_flow` para `build_whatsapp_flow_envelope`. O nome `send_whatsapp_flow` virou nova tool high-level com signature `(user_number, service_type)` que requer user_number — não wired no Engine framework.

## Fixes

- **prompt module interactive_response**: aponta LLM pra `build_whatsapp_flow_envelope` (renomeado, mesma signature do antigo). REGRA CRÍTICA explícita: NÃO chamar `send_whatsapp_flow` high-level até user_number injection wired.
- **__init__.py gate**: trata `send_whatsapp_flow` como alias legacy do low-level pra migration compat.
- **deploy.py**: exclui `send_whatsapp_flow` high-level sempre + auto-adiciona `build_whatsapp_flow_envelope` quando operator tem `send_whatsapp_flow` na config legada.
- **src/tools.py (shared loader)**: aplica safety exclusions no caminho compartilhado — afeta deploy + interactive_test + pre_deploy tests.

## Test plan

- [x] 38 unit tests passam
- [x] Codex review 7 passes — limpo
- [ ] Deploy staging via /deploy after merge
- [ ] Validar via WhatsApp: agent pode chamar build_whatsapp_flow_envelope pra abrir Flow proativo

🤖 Generated with [Claude Code](https://claude.com/claude-code)