### PR TITLE
fix(prompts): 4 erros de UX no bot observados em teste real WhatsApp

### DIFF
--- a/src/prompt_modules/media_inbound.py
+++ b/src/prompt_modules/media_inbound.py
@@ -78,9 +78,30 @@ Quando a entrada do cidadão começar com `[INBOUND_MEDIA]`, **NÃO** trate como
    - **Imagem:** chame `analyze_inbound_image` em seguida, quando disponível (conforme módulo `vision_inbound` deste prompt).
    - **Áudio:** chame `analyze_inbound_audio` em seguida, quando disponível (conforme módulo `audio_inbound` deste prompt) — a tool transcreve a fala e retorna intenção + workflow sugerido.
    - **Vídeo:** chame `analyze_inbound_video` em seguida, quando disponível (conforme módulo `video_inbound` deste prompt) — a tool analisa frames + áudio do vídeo e retorna descrição + transcrição + workflow sugerido.
-   - **Localização:** ainda não tem caminho de processamento direto — siga o protocolo de geocoding via texto descrito mais abaixo (caso `media_type=unsupported`).
+   - **Localização (`media_type=location`):** quando o cidadão compartilha pin do WhatsApp, o JSON `media` traz `latitude` e `longitude`. **NÃO peça endereço em texto** — chame uma tool que aceite coordenadas, como `reverse_geocode_address(latitude, longitude)`, quando ela estiver disponível. Detalhes no caso especial de `media_type=location` mais abaixo.
 
    Quando o módulo correspondente (`vision_inbound`/`audio_inbound`/`video_inbound`) estiver presente neste prompt e a tool estiver listada, use-os. Quando o módulo NÃO estiver presente OU a tool NÃO estiver listada, mantenha o fallback genérico do `register_inbound_media` (mensagem amigável pedindo texto).
+
+### Caso especial: `media_type=location` (pin do WhatsApp com lat/lng)
+
+Quando o cidadão compartilha localização pelo WhatsApp ("anexo → localização"), o JSON `media` traz `latitude` e `longitude` (e às vezes `address`/`name`).
+
+**Não rejeite a localização pedindo "envie em texto"** — isso quebra a UX: o cidadão acabou de fornecer o dado, só não no formato que você pediu. Em vez disso:
+
+1. Chame `register_inbound_media(media_type="location", user_number=..., latitude=..., longitude=..., address=...)` pra audit.
+2. **No mesmo turno**, resolva as coordenadas pra endereço estruturado. Caminhos possíveis (use o que estiver disponível):
+   - **`reverse_geocode_address(latitude=<lat>, longitude=<lng>)`** quando a tool estiver listada — este é o caminho correto para coordenadas cruas.
+   - **`validate_address(address=<texto>)`** somente se o JSON `media.address`/`media.name` já trouxer texto de endereço suficiente. Não passe latitude/longitude para `validate_address`.
+   - **Outra tool explicitamente documentada como aceitando lat/lng**, se disponível.
+   - Se nenhuma tool disponível aceitar coordenadas e não houver texto de endereço no JSON, explique que recebeu a localização, mas precisa confirmar o endereço em texto para continuar.
+3. **Apresente o endereço resolvido pro cidadão COM DISCLOSURE explícito da origem.** Não pergunte "Você se refere a Rua X?" — isso soa como se ele tivesse mencionado. Use formato:
+
+   > Pela localização que você compartilhou, identifiquei *Rua X, número Y - Bairro*. Está correto?
+
+4. Aguarde confirmação. Se "sim", prossiga com esse endereço como dado confirmado no histórico do thread (importante: workflows downstream, especialmente `multi_step_service` pós-Flow, devem enriquecer payload com esse endereço — ver módulo `whatsapp_flow_inbound`).
+5. Se o cidadão corrigir ("não, é a Rua Z"), use a correção dele como endereço.
+
+**Nunca apresente endereço como fato consumado sem disclosure.** O cidadão precisa entender que VOCÊ resolveu a localização dele, não que ele te disse o endereço.
 
 ### Caso especial: `media_type=unsupported` (geocoding via texto)
 

--- a/src/prompt_modules/whatsapp_flow_inbound.py
+++ b/src/prompt_modules/whatsapp_flow_inbound.py
@@ -56,22 +56,37 @@ Quando a mensagem do cidadão começar com `[SYSTEM] O cidadão preencheu o form
 
    Se nenhum mapeamento bate, default = `reparo_luminaria` (único Flow registrado no Meta hoje — `FLOW_LUMINARIA_ID=4141008006029185`). Logue warning mental sobre flow_id desconhecido.
 
-3. **Chame `multi_step_service` IMEDIATAMENTE** (antes de qualquer texto pro cidadão):
+3. **ANTES de chamar a tool: enriqueça o `payload` com campos JÁ CONFIRMADOS no histórico desta conversa.**
+
+   O Flow do WhatsApp **só captura** campos específicos do formulário (ex: `defect_type`, `qty_pattern`, `location` pra `reparo_luminaria`). Mas o workflow MCP `multi_step_service` exige outros campos (endereço da via, CPF, etc.) que provavelmente foram coletados antes do Flow ser enviado — em mensagens anteriores onde o cidadão já confirmou esses dados.
+
+   Antes da tool call, revise o histórico desta thread e identifique:
+   - **Endereço da via** (rua/número/bairro) — se cidadão confirmou em turn anterior (ex: "Sim" pra "Rua X, 100, Bairro Y?"), inclua como `endereco` ou `address` no payload.
+   - **Coordenadas** (latitude/longitude) — se já resolvidas via `validate_address` ou enviadas como location pin, inclua.
+   - **CPF** — se cidadão informou, inclua. Se cidadão recusou, inclua `cpf=null`; o workflow consome esse campo para pular CPF sem perguntar de novo.
+   - **Outros campos confirmados** que façam sentido pro service_name escolhido.
+
+   Sem essa enriquecimento, o workflow vai retornar `collect_address`/`collect_cpf` e o bot pergunta de novo dados que o cidadão já forneceu — quebra confiança.
+
+4. **Chame `multi_step_service` IMEDIATAMENTE** (antes de qualquer texto pro cidadão):
 
    ```
    multi_step_service(
      service_name="<mapeado no passo 2>",
      user_id="<telefone do cidadão, E.164 sem '+'>",
      payload={
+       **<campos confirmados no histórico do passo 3>,
        **<json extraído do passo 1>,
        "_source": "whatsapp_flow"
      }
    )
    ```
 
+   **Ordem importa:** o JSON do Flow vem POR ÚLTIMO no unpack pra que valores submetidos no formulário **sobrescrevam** histórico de campos com mesmo nome. Cenário: cidadão mencionou "defeito é luminária apagada" cedo, mas no Flow escolheu "piscando" — o Flow é a fonte autoritativa por ser input explícito mais recente.
+
    **CRÍTICO `_source="whatsapp_flow"`:** sem isso, o workflow auto-trigger reenvia o Flow ao cidadão (loop). O `multi_step_service` já tem lógica `workflow_is_active` + `is_new_request` (commits 9dc6e6c/e0e56b9/13bd660 da Gabs) que evita re-envio quando `_source=whatsapp_flow` no payload.
 
-4. **Use o retorno do `multi_step_service` como base da resposta ao cidadão.** O workflow internalmente faz alias dos campos (`defect_type → luminaria_defeito`, `qty_pattern → luminaria_quantidade + luminaria_intercaladas_bloco`, `location → luminaria_localizacao`), avança o state, e retorna a próxima pergunta (ex: "Onde está localizada a luminária? 1. Calçada...").
+5. **Use o retorno do `multi_step_service` como base da resposta ao cidadão.** O workflow internalmente faz alias dos campos (`defect_type → luminaria_defeito`, `qty_pattern → luminaria_quantidade + luminaria_intercaladas_bloco`, `location → luminaria_localizacao`), avança o state, e retorna a próxima pergunta (ex: "Onde está localizada a luminária? 1. Calçada...").
 
    Combine: (a) ack curto do form ("Recebi seu formulário."), (b) string retornada pelo `multi_step_service`. NÃO invente pergunta — use a que o workflow retornou.
 
@@ -80,11 +95,16 @@ Quando a mensagem do cidadão começar com `[SYSTEM] O cidadão preencheu o form
 ```
 USER: [SYSTEM] O cidadão preencheu o formulário WhatsApp. Dados recebidos: {"defect_type":"Apagada","qty_pattern":"uma"}. AÇÃO OBRIGATÓRIA: Chame a ferramenta multi_step_service imediatamente com esses dados no campo 'payload' (adicione _source='whatsapp_flow'). Identifique o service_name correto baseado nos campos recebidos.
 
-ASSISTANT (tool call PRIMEIRO, sem texto):
+ASSISTANT (tool call PRIMEIRO, sem texto — note `endereco` enriquecido do histórico):
 multi_step_service(
   service_name="reparo_luminaria",
   user_id="5521989091014",
-  payload={"defect_type": "Apagada", "qty_pattern": "uma", "_source": "whatsapp_flow"}
+  payload={
+    "defect_type": "Apagada",
+    "qty_pattern": "uma",
+    "endereco": "Rua Guilhermina Guinle, 170, Botafogo",  # confirmado pelo cidadão antes do Flow
+    "_source": "whatsapp_flow"
+  }
 )
 
 TOOL RETURNS: "Onde está localizada a luminária com defeito? Escolha uma opção:\\n1. Calçada\\n2. Fachada\\n..."

--- a/src/prompt_modules/workflow_continuation.py
+++ b/src/prompt_modules/workflow_continuation.py
@@ -22,6 +22,27 @@ valor recebido e use o retorno da ferramenta para compor a resposta ao cidadao.
 Caso critico: se a etapa pediu CPF e o cidadao disser "continuar sem CPF",
 "nao quero me identificar", "prefiro nao informar CPF", "anonimo" ou variacao
 equivalente, continue o workflow marcando CPF ausente/recusado (ex.:
-`cpf=null`, `identificacao_recusada=true` ou campo equivalente esperado pelo
-workflow). Nao responda apenas "vou seguir sem CPF" sem chamar a tool.
+`cpf=null` ou campo equivalente esperado pelo workflow). Nao responda apenas
+"vou seguir sem CPF" sem chamar a tool.
+
+## Detecção de pivot (troca de serviço mid-workflow)
+
+Se o cidadão estiver com um workflow X ativo e enviar mensagem mencionando um
+serviço DIFERENTE (ex: workflow ativo = `poda_de_arvore`, cidadão diz "quero
+abrir reparo de luminária"), **NÃO mude silenciosamente pra o novo serviço**.
+
+Pivot silencioso quebra confiança: deixa solicitação anterior em limbo e o
+cidadão não sabe se a primeira foi cancelada ou está paralela.
+
+Protocolo:
+
+1. Reconheça explicitamente o pivot: "Vi que você quer abrir um chamado de
+   *reparo de luminária*. Você quer cancelar a solicitação de *poda de árvore*
+   que estamos abrindo e seguir só com a luminária?"
+2. Aguarde confirmação clara do cidadão (sim/não).
+3. Se sim: encerre/marque cancelado o workflow anterior (chame
+   `multi_step_service` do workflow antigo com sinal de cancelamento se a tool
+   suporta, ou apenas pare de mantê-lo ativo) e inicie o novo workflow.
+4. Se não: pergunte o que quer fazer — pode ser que queira tratar os dois
+   separadamente em sequência. Mantenha o workflow ativo até resolução.
 """


### PR DESCRIPTION
## Summary
Corrige 4 erros de UX recorrentes do bot WhatsApp observados em teste real do operador no celular (phone 5521965850470, 19/05 10:53-10:57). Mudanças são **prompt-only** em `src/prompt_modules/` — sem efeito em código Python ou tools MCP.

## Erros corrigidos

| # | Erro | Onde | Tipo |
|---|---|---|---|
| 1 | Localização rejeitada na 1ª passagem, aceita depois (UX inconsistente) | `media_inbound.py` | Comportamento turn-a-turn |
| 2 | Pivot silencioso entre workflows (poda → luminária sem confirmar) | `workflow_continuation.py` | Confirmação ausente |
| 3 | Endereço resolvido apresentado sem disclosure da origem | `media_inbound.py` | Transparência |
| 4 | **Re-pergunta endereço após Flow** (mais grave — quebra confiança em fluxo multi-turn) | `whatsapp_flow_inbound.py` | Amnésia de payload enrichment |

## Diagnóstico do Erro 4 (mais técnico)

- Flow JSON `reparo_luminaria` coleta apenas `{defect_type, qty_pattern, location}` (tipo de local: Calçada/Praça/etc, **não** endereço da via)
- Workflow `multi_step_service/workflows/reparo_luminaria/workflow.py:64` tem `address_required=True`
- LLM chamava `multi_step_service` com payload do Flow apenas → workflow retornava `collect_address` → bot perguntava endereço de novo (mesmo após user já ter confirmado em turn anterior)

**Fix:** prompt agora exige enriquecimento do payload com campos **JÁ CONFIRMADOS** no histórico antes da tool call. Ordem do unpack: histórico primeiro, Flow por último (Flow é fonte autoritativa em caso de correção).

## Codex review uncommitted (3 rounds)

- **Round 1 P2:** `validate_address` não aceita lat/lng → trocado pra `reverse_geocode_address(latitude, longitude)`.
- **Round 1 P2:** `identificacao_recusada=true` ignorado pelo workflow → simplificado pra `cpf=null`.
- **Round 2 P2:** ordem do unpack do payload — Flow submission por último (autoridade) em vez de primeiro.
- **Round 3:** clean — "prompt-only updates and do not introduce an identifiable regression".

## Test plan

- [x] Codex review clean
- [x] Engine pytest unit (38 tests) — passa baseline
- [ ] **Deploy staging via `/deploy staging`** após merge
- [ ] Teste manual no WhatsApp com mesmas 4 condições:
  - [ ] Mandar location pin — bot deve resolver via reverse geocoding + dizer "Pela localização que você compartilhou, identifiquei X. Confere?"
  - [ ] Iniciar workflow A, pedir workflow B — bot deve perguntar "quer cancelar A?"
  - [ ] Confirmar endereço, depois receber Flow, preencher — bot **não** deve perguntar endereço de novo
- [ ] Validar que comportamento existente (text-only flow, audio response, image inbound) não regrediu

## Refs

- Real test conversation: 19/05 10:53-10:57 com phone 5521965850470
- Diagnóstico técnico: sessão Claude Code 2026-05-19
- Workflow MCP: `app-mcp-server/src/tools/multi_step_service/workflows/reparo_luminaria/`
