### PR TITLE
fix(checkpointer): pre-ping no pool psycopg (incidente 2026-05-21)

### DIFF
--- a/engine/agent.py
+++ b/engine/agent.py
@@ -1365,6 +1365,16 @@ class Agent(AsyncQueryable, AsyncStreamQueryable, Queryable, StreamQueryable):
                 max_size=10,
                 timeout=30.0,
                 open=True,  # Auto-open on creation
+                # Pre-ping antes de entregar a conexão pro caller. Sem isso, conexões
+                # ficam zumbis quando o cloudsql-proxy/ILB no GKE recicla pods e o pool
+                # entrega sockets mortos pro LangGraph (incidente 2026-05-21).
+                check=AsyncConnectionPool.check_connection,
+                # Recicla conexão ociosa há mais de 5min pra reduzir janela de
+                # detecção de drop silencioso entre rollouts do proxy.
+                max_idle=300.0,
+                # Tempo máximo tentando reabrir conexão antes de propagar erro
+                # pro chamador. Default infinito mascara DB inacessível.
+                reconnect_timeout=30.0,
             )
             logger.info("[Agent Setup] ✓ Connection pool created")
 


### PR DESCRIPTION
## Contexto

Espelha [#70](https://github.com/prefeitura-rio/app-eai-agent-engine/pull/70) (base master) pra branch staging conforme política staging-first do projeto.

Incidente em produção 2026-05-21 ~12:00–13:30 UTC: rollout do `cloudsql-proxy` no cluster GKE `application` (`gcr.io/cloudsql-docker/gce-proxy:1.23.0` → `gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.21.3`) derrubou o pool psycopg do Reasoning Engine de produção (`5326509863725957120`).

Sintoma: `psycopg.OperationalError: consuming input failed: server closed the connection unexpectedly` em todo `aget_tuple` do checkpointer LangGraph. Bot WhatsApp fora do ar pra usuário final por ~30min até autocura.

## Mudança

3 kwargs em `engine/agent.py:1142` (`AsyncConnectionPool`), todos suportados pelo `psycopg_pool 3.3.0` travado em `uv.lock`:

- `check=AsyncConnectionPool.check_connection` — SELECT 1 antes de entregar conexão
- `max_idle=300.0` — recicla conexão ociosa em 5min
- `reconnect_timeout=30.0` — propaga erro em vez de pendurar

## Validação

- API confirmada via `inspect.signature(AsyncConnectionPool.__init__)` em psycopg_pool 3.3.0
- `AsyncConnectionPool.check_connection` é staticmethod nativo
- Codex review uncommitted aprovou: "I did not find any actionable regression"

## Plano de promoção

Esse PR aqui valida em staging. Próximo `/deploy` em staging cria Reasoning Engine novo no Vertex. Após validação, promover via PR staging → master normal (#70 fica aberto como referência, pode ser fechado em favor de um merge staging→master limpo).

## Itens complementares (não nesse PR)

1. `DATABASE_HOST=10.0.0.54` → `10.0.0.109` no Infisical (IP zumbi; ILB real está em .109)
2. Churn do `postgres-ilb` (`UpdatedLoadBalancer x275 em 29h`) — investigar node pool autoscale
3. Processo de promoção `REASONING_ENGINE_ID` pra Infisical prod (engine atual é de 30-mar, 2 meses sem update)

🤖 Gerado com [Claude Code](https://claude.com/claude-code)