### PR TITLE
feat(prompt): gov.br auth-gating + injeta user_number no thread-id hook (#221)

### DIFF
--- a/engine/agent.py
+++ b/engine/agent.py
@@ -925,18 +925,22 @@ class Agent(AsyncQueryable, AsyncStreamQueryable, Queryable, StreamQueryable):
         extract_user_id=extract_thread_id_from_config
     )
     def _inject_thread_id_in_user_id_params(self, state, config=None):
-        """Hook para injetar thread_id em qualquer parâmetro user_id de tool calls.
+        """Hook para injetar thread_id em parâmetros user_id/user_number de tool calls.
 
         Este hook processa todas as tool calls e substitui qualquer parâmetro
-        'user_id' pelo thread_id atual, garantindo que todas as ferramentas
-        recebam o identificador correto do usuário.
+        'user_id' OU 'user_number' pelo thread_id atual, garantindo que todas
+        as ferramentas recebam o identificador correto do cidadão SEM depender
+        do LLM adivinhar o telefone (as tools de auth gov.br
+        ``govbr_auth_init/status/logout`` usam ``user_number``; sem essa
+        injeção o LLM alucinaria o número em fluxos de texto — ver nota em
+        ``prompt_modules/interactive_response.py``).
 
         Args:
             state: Estado do grafo contendo as mensagens
             config: Configuração do LangGraph (pode ser None em alguns contextos)
 
         Returns:
-            dict: Estado atualizado com thread_id injetado em todos os parâmetros user_id
+            dict: Estado atualizado com thread_id injetado em todos os parâmetros user_id/user_number
         """
         messages = state.get("messages", [])
 
@@ -960,14 +964,14 @@ class Agent(AsyncQueryable, AsyncStreamQueryable, Queryable, StreamQueryable):
             for message in reversed(messages):
                 if hasattr(message, "tool_calls") and message.tool_calls:
                     for tool_call in message.tool_calls:
-                        # Verifica se a tool call tem argumentos e se possui user_id
-                        if (
-                            "args" in tool_call
-                            and isinstance(tool_call["args"], dict)
-                            and "user_id" in tool_call["args"]
+                        # Substitui user_id E user_number pelo thread_id atual
+                        # (qualquer um que a tool exponha como argumento).
+                        if "args" in tool_call and isinstance(
+                            tool_call["args"], dict
                         ):
-                            # Substitui user_id pelo thread_id
-                            tool_call["args"]["user_id"] = thread_id
+                            for _id_param in ("user_id", "user_number"):
+                                if _id_param in tool_call["args"]:
+                                    tool_call["args"][_id_param] = thread_id
                     break  # Processa apenas a última mensagem AI
 
         return {"messages": messages}

--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -33,6 +33,7 @@ from typing import Tuple
 from src.prompt_modules import (
     audio_inbound,
     audio_response,
+    govbr_auth_gating,
     interactive_response,
     media_inbound,
     media_response,
@@ -107,6 +108,17 @@ _interactive_response_enabled = (
     )
 )
 
+# `govbr_auth_gating` gate: instrui o LLM a usar as tools de auth gov.br
+# (govbr_auth_init/status/logout) só quando elas estão bound E o kill-switch
+# ENABLE_GOVBR_AUTH não está "false". Sem isso, em deployment sem auth gov.br
+# o LLM seria orientado a chamar tool não-bound (erro de tool unknown).
+_govbr_auth_enabled = (
+    (_getenv_or_action("ENABLE_GOVBR_AUTH", action="ignore", default="true") or "true").lower() != "false"
+    and "govbr_auth_init" not in _excluded_tools
+    and "govbr_auth_status" not in _excluded_tools
+    and "govbr_logout" not in _excluded_tools  # módulo instrui logout — exige a tool bound
+)
+
 ENABLED_MODULES = [
     workflow_continuation,
     media_inbound,
@@ -121,6 +133,8 @@ if _media_response_enabled:
     ENABLED_MODULES.append(media_response)
 if _interactive_response_enabled:
     ENABLED_MODULES.append(interactive_response)
+if _govbr_auth_enabled:
+    ENABLED_MODULES.append(govbr_auth_gating)
 
 
 def compose(base_prompt: str, base_version: str) -> Tuple[str, str]:

--- a/src/prompt_modules/govbr_auth_gating.py
+++ b/src/prompt_modules/govbr_auth_gating.py
@@ -1,0 +1,69 @@
+"""
+Prompt module — gating de autenticação gov.br (identidade verificada via idRio).
+
+A infraestrutura OAuth2/PKCE já está deployada e funcionando (Gateway:
+`/api/v1/auth/govbr/initiate` + `/auth/govbr/callback`; MCP: tools
+``govbr_auth_init`` / ``govbr_auth_status`` / ``govbr_logout``). O que faltava
+era o Engine DECIDIR quando exigir autenticação e consumir o resultado — este
+módulo fecha essa lacuna elevando o protocolo pro system prompt (mais forte que
+deixar o LLM adivinhar).
+
+Política (aprovada 2026-05-25): exige identidade verificada apenas para ações
+que acessam/alteram dado pessoal vinculado ao CPF (multas, IPTU, status de
+processo, dados cadastrais, agendamentos vinculados). Informação pública e
+abertura de chamado de zeladoria anônimo NÃO exigem auth.
+
+Realidade operacional: o callback do Gateway ainda NÃO notifica o WhatsApp de
+volta (TODO no `govbr_callback.go` deployado). Logo o bot não recebe sinal
+automático de "autenticou"; precisa RE-checar ``govbr_auth_status`` na próxima
+mensagem do cidadão e então retomar a ação pendente. Esse protocolo está
+codificado abaixo pra NÃO depender daquele TODO (que exigiria redeploy do
+gateway).
+
+Enforcement — LIMITAÇÃO IMPORTANTE: este gating é de ORQUESTRAÇÃO (prompt), NÃO
+uma fronteira de segurança dura. Tool calls na mesma AIMessage executam em
+paralelo, então um LLM mal-comportado poderia emitir a tool de serviço restrito
+junto com ``govbr_auth_status`` e acessar dado antes de confirmar identidade. A
+barreira DURA deve viver nas tools de dados CPF-bound (verificar token gov.br
+server-side) ou num guard de execução de tool no Engine — trabalho futuro,
+atrelado às tools de dados (que ainda não existem). O prompt abaixo mitiga
+instruindo o LLM a NÃO chamar restrito junto com o status, mas não substitui a
+verificação no nível da tool.
+
+Tools consumidas (nomes exatos — MCP app-mcp-server):
+- ``govbr_auth_status(user_number)`` -> {is_authenticated, token_valid, expires_in, user_info}
+- ``govbr_auth_init(user_number, service_context)`` -> {status, auth_url, auth_id, expires_in}
+- ``govbr_logout(user_number)`` -> {status}
+"""
+
+MODULE_NAME = "govbr_auth_gating"
+
+MODULE_PROMPT = """\
+## Autenticação gov.br (identidade verificada)
+
+Alguns serviços exigem **identidade verificada** do cidadão via gov.br (login único). Sua função é gatear esses serviços: nunca executar uma ação restrita sem identidade confirmada, e nunca pedir login para o que é público.
+
+### Quando EXIGE autenticação (dado pessoal vinculado ao CPF)
+- Consultar ou alterar **multas**, **IPTU**, **status de processo/protocolo**, **dados cadastrais** do cidadão;
+- **Agendamentos** vinculados ao CPF do cidadão.
+
+### Quando NÃO exige (não peça login)
+- Informação pública: horários, endereços, "como faço X", requisitos, telefones;
+- Abertura de **chamado de zeladoria anônimo** (ex: luminária apagada) — segue o fluxo normal, sem login.
+
+### Protocolo (siga exatamente)
+1. **Ao detectar pedido de serviço restrito**, ANTES de executar, chame `govbr_auth_status(user_number=<número do cidadão>)`.
+2. **Se `is_authenticated` e `token_valid` forem verdadeiros** → identidade confirmada; prossiga normalmente com o serviço.
+3. **Se NÃO autenticado** → chame `govbr_auth_init(user_number=<número do cidadão>, service_context="<serviço>")` (identificador curto: `iptu`, `multas`, `processo`, `dados_cadastrais`, `agendamento`). Pegue `auth_url` da resposta e apresente ao cidadão de forma clara e acolhedora, por exemplo:
+   > "Pra [consultar suas multas] preciso confirmar sua identidade no gov.br. Toque no link, faça login e volte aqui que eu continuo: {auth_url}\\n(O link expira em alguns minutos.)"
+   **NÃO execute o serviço restrito** enquanto a identidade não estiver confirmada.
+4. **Quando o cidadão voltar** (qualquer mensagem depois de você enviar o link), **RE-cheque `govbr_auth_status` primeiro** — o sistema NÃO te avisa automaticamente que ele autenticou. Se agora estiver autenticado, **retome a ação pendente** sem pedir tudo de novo. Se ainda não, reforce com gentileza que falta concluir o login pelo link.
+5. **Logout**: se o cidadão pedir para desconectar, sair, ou "esquecer meus dados", chame `govbr_logout(user_number=<número do cidadão>)` e confirme.
+
+### Regras
+- O `<número do cidadão>` é o número de WhatsApp dele (E.164) — o mesmo identificador da conversa atual.
+- **Nunca** peça CPF ou senha diretamente no chat — a identidade é confirmada SÓ pelo link gov.br.
+- Um cidadão já autenticado não deve ser obrigado a logar de novo enquanto o token for válido (por isso o passo 1 vem antes de qualquer pedido de login).
+- Se a `auth_url` não vier (erro na tool), explique que houve um problema e ofereça tentar de novo — **não invente link**.
+- **Nunca** chame uma tool de serviço restrito na MESMA resposta em que chama `govbr_auth_status` — espere o resultado do status antes de prosseguir. Tools na mesma resposta executam em paralelo; chamar as duas juntas arriscaria acessar o dado antes de confirmar a identidade.
+"""

--- a/tests/govbr_orchestration_smoke.py
+++ b/tests/govbr_orchestration_smoke.py
@@ -1,0 +1,105 @@
+"""Smoke de ORQUESTRAÇÃO gov.br (local, Gemini real) — valida que o prompt module
+``govbr_auth_gating`` faz o LLM gatear serviço restrito atrás de auth e NÃO gatear
+serviço público.
+
+  uv run python tests/govbr_orchestration_smoke.py
+
+Roda SEM Engine/Postgres/Redis/Gateway — só precisa de GEMINI_API_KEY. Liga as
+tools reais (govbr_auth_*) + um serviço restrito (consultar_multas) + um público
+(horario_funcionamento) ao Gemini 2.5 Flash e observa os tool_calls.
+
+NÃO testa o round-trip de token (precisa login gov.br humano + Redis). Testa só a
+DECISÃO de tool-calling dado o prompt. O base prompt aqui é representativo
+(mínimo), não o system prompt pleno de prod — logo é indicativo, não definitivo.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.tools import tool
+
+from src.prompt_modules import govbr_auth_gating
+
+
+@tool
+def govbr_auth_status(user_number: str) -> dict:
+    """Verifica se o cidadão possui autenticação gov.br válida."""
+    return {}
+
+
+@tool
+def govbr_auth_init(user_number: str, service_context: str = "consulta_dados") -> dict:
+    """Inicia o fluxo de autenticação gov.br; retorna a auth_url para o cidadão."""
+    return {}
+
+
+@tool
+def govbr_logout(user_number: str) -> dict:
+    """Faz logout do cidadão, revogando o token gov.br."""
+    return {}
+
+
+@tool
+def consultar_multas(user_number: str) -> dict:
+    """Consulta as multas de trânsito do cidadão (dado pessoal vinculado ao CPF)."""
+    return {}
+
+
+@tool
+def horario_funcionamento(unidade: str) -> dict:
+    """Informa o horário de funcionamento de uma unidade (informação pública)."""
+    return {}
+
+
+_BASE = (
+    "Você é o assistente virtual da Prefeitura do Rio no WhatsApp. Ajude o "
+    "cidadão de forma cordial. Use as ferramentas disponíveis quando apropriado."
+)
+
+# (rótulo, mensagem do cidadão) — a checagem por rótulo está no loop em main()
+_CASES = [
+    ("restrito", "Quero consultar minhas multas de trânsito"),
+    ("público", "Qual o horário de funcionamento da prefeitura hoje?"),
+]
+
+
+def main() -> int:
+    if not (os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")):
+        print("SKIP: sem GEMINI_API_KEY/GOOGLE_API_KEY no env.")
+        return 0
+
+    from langchain_google_genai import ChatGoogleGenerativeAI
+
+    system = _BASE + "\n\n" + govbr_auth_gating.MODULE_PROMPT
+    llm = ChatGoogleGenerativeAI(model="gemini-2.5-flash", temperature=0).bind_tools(
+        [govbr_auth_status, govbr_auth_init, govbr_logout, consultar_multas, horario_funcionamento]
+    )
+
+    ok = True
+    for label, msg in _CASES:
+        try:
+            resp = llm.invoke([SystemMessage(content=system), HumanMessage(content=msg)])
+        except Exception as exc:  # nunca ecoa a key
+            # exit 2 = NÃO-AVALIADO (erro de rede/quota/Gemini), distinto de
+            # exit 1 = gating incorreto. Operador/CI não confunde os dois.
+            print(f"  [{label}] INDETERMINADO (erro ao invocar Gemini, não é falha de gating): {type(exc).__name__}: {exc}")
+            return 2
+        calls = [c["name"] for c in (resp.tool_calls or [])]
+        if label == "restrito":
+            # gateado: checa auth_status e NÃO chama o serviço restrito ainda
+            # (este último também cobre a mitigação do same-turn parallel call)
+            passed = "govbr_auth_status" in calls and "consultar_multas" not in calls
+        else:
+            passed = "govbr_auth_status" not in calls and "govbr_auth_init" not in calls
+        ok = ok and passed
+        print(f"  [{label}] msg={msg!r}\n    tool_calls={calls}  -> {'PASS' if passed else 'FAIL'}")
+
+    print("PASS: orquestração gateia restrito e libera público." if ok else "FAIL: gating incorreto.")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_agent_injection.py
+++ b/tests/unit/test_agent_injection.py
@@ -1,0 +1,62 @@
+"""Testes do hook de injeção de identificador (``engine.agent.Agent``).
+
+``_inject_thread_id_in_user_id_params`` reescreve ``user_id`` E ``user_number``
+nas tool calls com o ``thread_id`` (telefone do cidadão, vindo do
+``config.configurable``), pra que as tools de auth gov.br
+(``govbr_auth_init/status/logout`` — que usam ``user_number``) recebam o número
+correto sem o LLM precisar adivinhá-lo em fluxos de texto.
+
+O método não usa ``self``, então é chamável unbound com ``self=None`` — evita
+instanciar o Agent (que exige env/GCP).
+"""
+
+from engine.agent import Agent
+
+_THREAD = "5521999999999"
+
+
+class _AIMsg:
+    """Stub mínimo de AIMessage que carrega ``tool_calls``."""
+
+    def __init__(self, tool_calls):
+        self.tool_calls = tool_calls
+
+
+def _inject(tool_calls, thread_id=_THREAD, configurable=None):
+    state = {"messages": [_AIMsg(tool_calls)]}
+    config = {"configurable": configurable if configurable is not None else {"thread_id": thread_id}}
+    Agent._inject_thread_id_in_user_id_params(None, state, config)
+    return tool_calls
+
+
+def test_injects_user_number_for_govbr_tools():
+    # o caso que estava quebrado: gov.br tools usam user_number.
+    tc = [{"name": "govbr_auth_status", "args": {"user_number": "PLACEHOLDER"}}]
+    _inject(tc)
+    assert tc[0]["args"]["user_number"] == _THREAD
+
+
+def test_still_injects_user_id():
+    tc = [{"name": "multi_step_service", "args": {"user_id": "X", "service_name": "reparo"}}]
+    _inject(tc)
+    assert tc[0]["args"]["user_id"] == _THREAD
+    assert tc[0]["args"]["service_name"] == "reparo"  # demais args intactos
+
+
+def test_injects_both_params_in_same_call():
+    tc = [{"name": "weird_tool", "args": {"user_id": "A", "user_number": "B"}}]
+    _inject(tc)
+    assert tc[0]["args"]["user_id"] == _THREAD
+    assert tc[0]["args"]["user_number"] == _THREAD
+
+
+def test_no_thread_id_leaves_args_untouched():
+    tc = [{"name": "govbr_auth_status", "args": {"user_number": "PLACEHOLDER"}}]
+    _inject(tc, configurable={})  # sem thread_id
+    assert tc[0]["args"]["user_number"] == "PLACEHOLDER"
+
+
+def test_tool_without_id_param_untouched():
+    tc = [{"name": "get_info", "args": {"query": "horario"}}]
+    _inject(tc)
+    assert tc[0]["args"] == {"query": "horario"}

--- a/tests/unit/test_prompt_modules.py
+++ b/tests/unit/test_prompt_modules.py
@@ -11,6 +11,7 @@ tests pós-deploy em staging.
 from src.prompt_modules import compose, ENABLED_MODULES
 from src.prompt_modules import (
     audio_inbound,
+    govbr_auth_gating,
     media_inbound,
     vision_inbound,
     workflow_continuation,
@@ -186,6 +187,56 @@ def test_media_inbound_prompt_omits_unsupported_tool_params_in_call():
         f"Prompt usa {forbidden!r} em chamada da tool, "
         "mas a tool não aceita esse parâmetro"
     )
+
+
+# ---------- govbr_auth_gating (auth gov.br) ----------
+
+
+def test_govbr_auth_gating_module_name_is_stable():
+    """``MODULE_NAME`` vira sufixo no version — não pode mudar silenciosamente."""
+    assert govbr_auth_gating.MODULE_NAME == "govbr_auth_gating"
+    assert isinstance(govbr_auth_gating.MODULE_PROMPT, str)
+
+
+def test_govbr_auth_gating_prompt_mentions_the_three_tools():
+    """Guard contra deleção dos nomes EXATOS das tools MCP — se o prompt não
+    citar, o LLM não sabe o que chamar."""
+    p = govbr_auth_gating.MODULE_PROMPT
+    assert "govbr_auth_status" in p
+    assert "govbr_auth_init" in p
+    assert "govbr_logout" in p
+
+
+def test_govbr_auth_gating_checks_status_before_init():
+    """Política: checar status ANTES de pedir login — não obrigar re-auth de
+    quem já está autenticado (gating idempotente)."""
+    p = govbr_auth_gating.MODULE_PROMPT
+    assert p.index("govbr_auth_status") < p.index("govbr_auth_init")
+
+
+def test_govbr_auth_gating_lists_restricted_and_public_scope():
+    """Sanity da política aprovada: serviços restritos (CPF-bound) + exceção
+    pública (zeladoria anônima)."""
+    p = govbr_auth_gating.MODULE_PROMPT.lower()
+    assert "iptu" in p and "multas" in p, "serviços restritos ausentes"
+    assert "anônim" in p, "exceção de zeladoria anônima ausente"
+
+
+def test_govbr_auth_gating_enabled_by_default():
+    """Com env default, o módulo entra em ENABLED_MODULES. Env-aware: pula se o
+    ambiente legitimamente desabilita (ENABLED_MODULES é computado no import,
+    então não dá pra afirmar incondicionalmente sem recarregar o módulo)."""
+    import os
+
+    excluded = {t.strip() for t in (os.getenv("MCP_EXCLUDED_TOOLS") or "").split(",")}
+    disabled = (os.getenv("ENABLE_GOVBR_AUTH", "true").lower() == "false") or bool(
+        excluded & {"govbr_auth_init", "govbr_auth_status", "govbr_logout"}
+    )
+    if disabled:
+        import pytest
+
+        pytest.skip("gov.br auth desabilitado via env — gate funcionando como configurado")
+    assert govbr_auth_gating in ENABLED_MODULES
 
 
 # ---------- módulo vision_inbound ----------


### PR DESCRIPTION
## O que

Fecha a lacuna de **orquestração** que faltava pro auth gov.br/idRio funcionar no fluxo conversacional:

- **`src/prompt_modules/govbr_auth_gating.py`** (novo): instrui o bot a checar `govbr_auth_status` antes de pedir login, disparar `govbr_auth_init` pra serviços CPF-bound (multas, IPTU, processo, dados cadastrais, agendamento), apresentar a `auth_url`, re-checar na volta (o callback do gateway não notifica o WhatsApp — TODO deployado) e fazer `govbr_logout` sob pedido. Gateado por `ENABLE_GOVBR_AUTH` + as 3 tools bound. Info pública / zeladoria anônima **não** exigem auth.
- **`engine/agent.py`**: `_inject_thread_id_in_user_id_params` agora injeta `user_number` **além de** `user_id`. As tools gov.br usam `user_number`, que o LLM não tinha como suprir em fluxos de texto (risco de hallucination, já documentado em `interactive_response.py`). **Era o elo quebrado.**
- gate de logout + testes.

## Por quê

Gateway (OAuth/PKCE/callback/token), MCP tools e o client idRio já estavam deployados e funcionando, mas o Engine **nunca disparava** a auth nem conseguia passar o `user_number` correto. Esta PR fecha exatamente isso.

## Como testei

- `uv run pytest tests/unit/` → **48 passed** (5 de injeção `user_id`/`user_number` + 43 prompt_modules, incl. 5 do gating).
- **Smoke de orquestração contra Gemini 2.5 Flash real** (`tests/govbr_orchestration_smoke.py`): pedido restrito ("minhas multas") → `govbr_auth_status` primeiro, **não** chama o serviço restrito; pedido público ("horário") → nenhuma tool de auth. **PASS.**
- Revisão: Claude code-reviewer (opus) + `codex review` (gpt-5.5, xhigh) — contrato de tools verificado contra o MCP real, injeção sem regressão em `user_id`.

## Rollback

Aditivo e reversível: reverter o merge. O módulo é gateável por `ENABLE_GOVBR_AUTH=false`; a injeção adiciona `user_number` ao lado de `user_id` (sem mudar comportamento de tools `user_id` existentes).

## Caveats (importante pro time)

1. **Enforcement é orquestração (prompt), NÃO barreira de segurança dura** — tool calls na mesma AIMessage rodam em paralelo. A barreira real deve viver nas tools de dados CPF-bound (verificar token server-side) — trabalho futuro. Mitigado no prompt (não chamar restrito junto com o status).
2. **As tools de dados restritas (multas/IPTU lookup) ainda não existem** — então o gating hoje leva o cidadão ao login sem uma tool de fulfillment ao final. Avaliar se deploya com `ENABLE_GOVBR_AUTH=false` até as tools de dados existirem, ou aceitar o auth estabelecido pra quando vierem.
3. **Round-trip de token completo** não foi testado E2E (precisa login gov.br humano real + Redis compartilhado).

Refs: #221