### PR TITLE
chore(prompt): gov.br auth-gating opt-in (default OFF) até tools de dados existirem

### DIFF
--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -108,12 +108,16 @@ _interactive_response_enabled = (
     )
 )
 
-# `govbr_auth_gating` gate: instrui o LLM a usar as tools de auth gov.br
-# (govbr_auth_init/status/logout) só quando elas estão bound E o kill-switch
-# ENABLE_GOVBR_AUTH não está "false". Sem isso, em deployment sem auth gov.br
-# o LLM seria orientado a chamar tool não-bound (erro de tool unknown).
+# `govbr_auth_gating` gate: OPT-IN (default OFF). A feature fica DORMENTE até
+# (a) existirem as tools de dados CPF-bound que de fato consomem o token e
+# (b) a barreira de enforcement dura (ver docstring do módulo). Habilita só com
+# ENABLE_GOVBR_AUTH=true E as 3 tools (init/status/logout) bound. Default OFF
+# evita orientar o cidadão a autenticar sem uma tool de fulfillment ao final.
+# Nota: isto desliga só o PROMPT (como os demais módulos). Pra dormência TOTAL
+# (as tools govbr_auth_* nem bound no schema), excluí-las também via
+# MCP_EXCLUDED_TOOLS no env do Engine.
 _govbr_auth_enabled = (
-    (_getenv_or_action("ENABLE_GOVBR_AUTH", action="ignore", default="true") or "true").lower() != "false"
+    (_getenv_or_action("ENABLE_GOVBR_AUTH", action="ignore", default="false") or "false").lower() == "true"
     and "govbr_auth_init" not in _excluded_tools
     and "govbr_auth_status" not in _excluded_tools
     and "govbr_logout" not in _excluded_tools  # módulo instrui logout — exige a tool bound

--- a/tests/unit/test_prompt_modules.py
+++ b/tests/unit/test_prompt_modules.py
@@ -222,21 +222,26 @@ def test_govbr_auth_gating_lists_restricted_and_public_scope():
     assert "anônim" in p, "exceção de zeladoria anônima ausente"
 
 
-def test_govbr_auth_gating_enabled_by_default():
-    """Com env default, o módulo entra em ENABLED_MODULES. Env-aware: pula se o
-    ambiente legitimamente desabilita (ENABLED_MODULES é computado no import,
-    então não dá pra afirmar incondicionalmente sem recarregar o módulo)."""
-    import os
+def test_govbr_auth_gating_off_by_default():
+    """Default OFF (opt-in): a feature fica DORMENTE até ENABLE_GOVBR_AUTH=true
+    explícito (+ as 3 tools bound). Usa o MESMO source que o gate de produção
+    (getenv_or_action lê root .env + os.environ), pra não falhar falsamente
+    quando habilitado via .env. Pula se o ambiente habilita explicitamente."""
+    from src.utils.infisical import getenv_or_action
 
-    excluded = {t.strip() for t in (os.getenv("MCP_EXCLUDED_TOOLS") or "").split(",")}
-    disabled = (os.getenv("ENABLE_GOVBR_AUTH", "true").lower() == "false") or bool(
-        excluded & {"govbr_auth_init", "govbr_auth_status", "govbr_logout"}
-    )
-    if disabled:
+    excluded = {
+        t.strip()
+        for t in (getenv_or_action("MCP_EXCLUDED_TOOLS", action="ignore", default="") or "").split(",")
+        if t.strip()
+    }
+    explicitly_on = (
+        getenv_or_action("ENABLE_GOVBR_AUTH", action="ignore", default="false") or "false"
+    ).lower() == "true" and not (excluded & {"govbr_auth_init", "govbr_auth_status", "govbr_logout"})
+    if explicitly_on:
         import pytest
 
-        pytest.skip("gov.br auth desabilitado via env — gate funcionando como configurado")
-    assert govbr_auth_gating in ENABLED_MODULES
+        pytest.skip("ENABLE_GOVBR_AUTH=true (via env/.env) — habilitado explicitamente")
+    assert govbr_auth_gating not in ENABLED_MODULES
 
 
 # ---------- módulo vision_inbound ----------


### PR DESCRIPTION
## O que

Follow-up do #72: inverte o default do módulo `govbr_auth_gating` de **ON → OFF** (opt-in via `ENABLE_GOVBR_AUTH=true`). A feature de gating gov.br fica **dormente** em staging.

## Por quê

As **tools de dados restritas (multas/IPTU lookup) ainda não existem** — com o gating ligado, o cidadão seria mandado autenticar sem uma tool pra concluir o serviço. Default OFF deixa a infra pronta sem expor UX incompleta. Decisão do usuário após o merge do #72. Quando as tools de dados + a barreira de enforcement dura existirem, habilita com `ENABLE_GOVBR_AUTH=true`.

## Mudança

- `src/prompt_modules/__init__.py`: gate vira opt-in (`default="false"`, comparação `== "true"`).
- `tests/unit/test_prompt_modules.py`: `test_govbr_auth_gating_off_by_default` assert dormente por default; usa `getenv_or_action` (mesmo source `.env` + `os.environ` do gate de produção) pra não falhar falso quando habilitado via root `.env`.
- Comentário documenta: desliga só o **prompt** (como os demais módulos); dormência **total** (tools `govbr_auth_*` nem bound) exige excluí-las via `MCP_EXCLUDED_TOOLS`.

## Como testei

`uv run pytest tests/unit/test_prompt_modules.py` → **43 passed**. Review: Claude code-reviewer (opus) APPROVE + `codex review` (gpt-5.5, xhigh) — P2 do source do teste corrigido (getenv_or_action), P2 de tool-binding documentado.

## Rollback

Trivial: reverter o merge (volta a default ON) ou setar `ENABLE_GOVBR_AUTH=true`.

Refs: #72, #221