### PR TITLE
docs(prompt): instrução de voz TTS provider-neutral

### DIFF
--- a/src/prompt_modules/audio_response.py
+++ b/src/prompt_modules/audio_response.py
@@ -48,7 +48,7 @@ Quando o cidadão pedir explicitamente a resposta em áudio (ex: "responda por �
 
 ### Estilo PT-BR pra TTS
 
-A voz default é `pt-BR-Neural2-A` (Google Cloud TTS, feminina, neural). Ela pronuncia bem PT-BR mas ainda assim:
+A voz é PT-BR (configurada no MCP via provider TTS — Google Cloud TTS ou Gemini TTS; o `voice_used` retornado indica qual foi usada). Ela pronuncia bem PT-BR mas ainda assim:
 
 - **Use grafia natural**: "vou te ajudar" em vez de "irei ajudá-lo".
 - **Expanda abreviações**: "às 14h" → "às catorze horas"; "Rua XV de Novembro" → "Rua quinze de Novembro".


### PR DESCRIPTION
## What
Torna a instrução de voz do prompt module `audio_response.py` provider-neutral: remove o hardcode "voz default `pt-BR-Neural2-A` (Google Cloud TTS)" e passa a dizer que a voz é configurada no MCP via provider TTS (Google ou Gemini), com o `voice_used` retornado indicando qual rodou.

## Why
O MCP agora tem provider TTS switchável (`TTS_PROVIDER`: `google` default / `gemini` opt-in) com sotaque carioca best-effort — ver ADR-038 (study-sf) e o PR `feat/gemini-tts-carioca` no `app-mcp-server`. O prompt não deve acoplar a um provider/voz fixos.

## How tested
Mudança de texto de prompt (LLM-facing), 1 linha. Dual-review (claude code-reviewer opus + codex gpt-5.5 xhigh): ambos confirmaram que o campo `voice_used` existe no contrato da tool e que a redação está consistente com o resto do módulo. Pre-commit (warn-only MCP tool refs) passou.

## Rollback
`git revert 749efd1`. Sem efeito runtime além do texto do system prompt; reverter restaura a redação anterior.
