### PR TITLE
fix(prompt): gov.br gate desacoplado de MCP_EXCLUDED_TOOLS + fallback bloqueia restrito

### DIFF
--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -108,20 +108,15 @@ _interactive_response_enabled = (
     )
 )
 
-# `govbr_auth_gating` gate: OPT-IN (default OFF). A feature fica DORMENTE até
-# (a) existirem as tools de dados CPF-bound que de fato consomem o token e
-# (b) a barreira de enforcement dura (ver docstring do módulo). Habilita só com
-# ENABLE_GOVBR_AUTH=true E as 3 tools (init/status/logout) bound. Default OFF
-# evita orientar o cidadão a autenticar sem uma tool de fulfillment ao final.
-# Nota: isto desliga só o PROMPT (como os demais módulos). Pra dormência TOTAL
-# (as tools govbr_auth_* nem bound no schema), excluí-las também via
-# MCP_EXCLUDED_TOOLS no env do Engine.
+# `govbr_auth_gating` gate: OPT-IN, controlado SÓ por ENABLE_GOVBR_AUTH (default
+# OFF). O flag do operador é o switch único — sem acoplar a MCP_EXCLUDED_TOOLS,
+# que estava bloqueando a habilitação quando as tools govbr aparecem na exclusão
+# por motivo legado. A preocupação de "instruir tool não-bound" é tratada no
+# PRÓPRIO prompt do módulo (instrui o LLM a não chamar uma tool govbr que não
+# esteja disponível), em vez de derrubar o módulo inteiro.
 _govbr_auth_enabled = (
-    (_getenv_or_action("ENABLE_GOVBR_AUTH", action="ignore", default="false") or "false").lower() == "true"
-    and "govbr_auth_init" not in _excluded_tools
-    and "govbr_auth_status" not in _excluded_tools
-    and "govbr_logout" not in _excluded_tools  # módulo instrui logout — exige a tool bound
-)
+    _getenv_or_action("ENABLE_GOVBR_AUTH", action="ignore", default="false") or "false"
+).lower() == "true"
 
 ENABLED_MODULES = [
     workflow_continuation,

--- a/src/prompt_modules/govbr_auth_gating.py
+++ b/src/prompt_modules/govbr_auth_gating.py
@@ -66,4 +66,5 @@ Alguns serviços exigem **identidade verificada** do cidadão via gov.br (login 
 - Um cidadão já autenticado não deve ser obrigado a logar de novo enquanto o token for válido (por isso o passo 1 vem antes de qualquer pedido de login).
 - Se a `auth_url` não vier (erro na tool), explique que houve um problema e ofereça tentar de novo — **não invente link**.
 - **Nunca** chame uma tool de serviço restrito na MESMA resposta em que chama `govbr_auth_status` — espere o resultado do status antes de prosseguir. Tools na mesma resposta executam em paralelo; chamar as duas juntas arriscaria acessar o dado antes de confirmar a identidade.
+- Se alguma das tools `govbr_auth_status` / `govbr_auth_init` / `govbr_logout` **não estiver disponível** no seu conjunto de ferramentas, **não a invente nem a chame**. Como sem ela não dá pra confirmar identidade, **NÃO execute o serviço restrito** — informe que a autenticação está indisponível no momento e oriente o cidadão a tentar mais tarde ou por outro canal. (Serviços públicos seguem normalmente.)
 """

--- a/tests/unit/test_prompt_modules.py
+++ b/tests/unit/test_prompt_modules.py
@@ -224,19 +224,15 @@ def test_govbr_auth_gating_lists_restricted_and_public_scope():
 
 def test_govbr_auth_gating_off_by_default():
     """Default OFF (opt-in): a feature fica DORMENTE até ENABLE_GOVBR_AUTH=true
-    explícito (+ as 3 tools bound). Usa o MESMO source que o gate de produção
-    (getenv_or_action lê root .env + os.environ), pra não falhar falsamente
-    quando habilitado via .env. Pula se o ambiente habilita explicitamente."""
+    explícito (switch único — desacoplado de MCP_EXCLUDED_TOOLS). Usa o MESMO
+    source que o gate de produção (getenv_or_action lê root .env + os.environ),
+    pra não falhar falsamente quando habilitado via .env. Pula se o ambiente
+    habilita explicitamente."""
     from src.utils.infisical import getenv_or_action
 
-    excluded = {
-        t.strip()
-        for t in (getenv_or_action("MCP_EXCLUDED_TOOLS", action="ignore", default="") or "").split(",")
-        if t.strip()
-    }
     explicitly_on = (
         getenv_or_action("ENABLE_GOVBR_AUTH", action="ignore", default="false") or "false"
-    ).lower() == "true" and not (excluded & {"govbr_auth_init", "govbr_auth_status", "govbr_logout"})
+    ).lower() == "true"
     if explicitly_on:
         import pytest
 


### PR DESCRIPTION
## Problema

Após habilitar `ENABLE_GOVBR_AUTH=true` no Infisical staging + 2 deploys, o módulo `govbr_auth_gating` **continuava OFF** — o prompt deployado compunha `179+...+interactive_response` sem `+govbr_auth_gating`. Causa: o gate exigia `ENABLE_GOVBR_AUTH=true` **E** as 3 tools govbr NÃO em `MCP_EXCLUDED_TOOLS`. Staging tem `MCP_EXCLUDED_TOOLS` preenchido (provavelmente com as tools govbr, legado) → gate caía.

## Fix

- **Desacopla o gate:** agora gated SÓ por `ENABLE_GOVBR_AUTH=true` (default false). O flag do operador é o switch único.
- **Mitigação no prompt (em vez do hard-gate):** se uma tool govbr não estiver disponível, o LLM não a chama **e não executa o serviço restrito** (sem ela não dá pra confirmar identidade) — defere, não prossegue sem auth. Isso atende a preocupação original (codex P2 do #72) no lugar certo.

## Verificação

- 43 testes (`tests/unit/test_prompt_modules.py`).
- Prova local: `ENABLE_GOVBR_AUTH=true` + tools excluídas → módulo **ON** (`+govbr_auth_gating` no version); sem o flag → **OFF**.
- Review: Claude (opus) APPROVE (decouple correto, fallback bloqueia restrito) + codex (gpt-5.5, xhigh) — P1 do fallback (era "siga sem ela") corrigido pra bloquear.

## Próximo (operacional)

Após merge + `/deploy staging`, o version composto deve sair `...+interactive_response+govbr_auth_gating`. Cada deploy cria um novo `REASONING_ENGINE_ID` que precisa ir pro Infisical (key `REASONING_ENGINE_ID`, env staging) pro Gateway rotear pro engine novo.

Refs: #72, #73, #221