### PR TITLE
fix(prompt): normaliza ENABLE_GOVBR_AUTH (strip) + observabilidade dos gates

### DIFF
--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -28,6 +28,7 @@ agente (tom, escopo, fallbacks). Os módulos cobrem apenas integrações
 específicas que devem viver ao lado do código de tools.
 """
 
+import logging
 from typing import Tuple
 
 from src.prompt_modules import (
@@ -108,15 +109,23 @@ _interactive_response_enabled = (
     )
 )
 
+def _flag_is_true(raw: str | None) -> bool:
+    """Normaliza um flag booleano de env. Tolera whitespace (paste no Infisical
+    costuma deixar ``\\n``/espaço no valor) e caixa; só ``"true"`` liga. É mais
+    estrito que os gates ``!= "false"`` acima — auth é opt-in deliberado, então
+    qualquer coisa que não seja exatamente ``true`` (após strip/lower) fica OFF.
+    `getenv_or_action` não faz strip, então a normalização vive aqui."""
+    return (raw or "").strip().lower() == "true"
+
+
 # `govbr_auth_gating` gate: OPT-IN, controlado SÓ por ENABLE_GOVBR_AUTH (default
 # OFF). O flag do operador é o switch único — sem acoplar a MCP_EXCLUDED_TOOLS,
 # que estava bloqueando a habilitação quando as tools govbr aparecem na exclusão
 # por motivo legado. A preocupação de "instruir tool não-bound" é tratada no
 # PRÓPRIO prompt do módulo (instrui o LLM a não chamar uma tool govbr que não
 # esteja disponível), em vez de derrubar o módulo inteiro.
-_govbr_auth_enabled = (
-    _getenv_or_action("ENABLE_GOVBR_AUTH", action="ignore", default="false") or "false"
-).lower() == "true"
+_govbr_auth_raw = _getenv_or_action("ENABLE_GOVBR_AUTH", action="ignore", default="")
+_govbr_auth_enabled = _flag_is_true(_govbr_auth_raw)
 
 ENABLED_MODULES = [
     workflow_continuation,
@@ -134,6 +143,21 @@ if _interactive_response_enabled:
     ENABLED_MODULES.append(interactive_response)
 if _govbr_auth_enabled:
     ENABLED_MODULES.append(govbr_auth_gating)
+
+# Observability — os gates opcionais resolvem em import-time e ficam invisíveis
+# fora do sufixo de version. Logar a decisão (+ presença do flag govbr, SEM o
+# valor) torna o deploy diagnosticável: ``present=False`` => o flag não chegou
+# ao ambiente (problema de Infisical/projeto); ``present=True`` com
+# ``govbr_auth_gating=False`` => valor != "true".
+logging.getLogger(__name__).info(
+    "prompt_modules optional gates: audio_response=%s media_response=%s "
+    "interactive_response=%s govbr_auth_gating=%s (ENABLE_GOVBR_AUTH present=%s)",
+    _audio_response_enabled,
+    _media_response_enabled,
+    _interactive_response_enabled,
+    _govbr_auth_enabled,
+    bool((_govbr_auth_raw or "").strip()),
+)
 
 
 def compose(base_prompt: str, base_version: str) -> Tuple[str, str]:

--- a/tests/unit/test_prompt_modules.py
+++ b/tests/unit/test_prompt_modules.py
@@ -228,16 +228,33 @@ def test_govbr_auth_gating_off_by_default():
     source que o gate de produção (getenv_or_action lê root .env + os.environ),
     pra não falhar falsamente quando habilitado via .env. Pula se o ambiente
     habilita explicitamente."""
+    from src.prompt_modules import _flag_is_true
     from src.utils.infisical import getenv_or_action
 
-    explicitly_on = (
-        getenv_or_action("ENABLE_GOVBR_AUTH", action="ignore", default="false") or "false"
-    ).lower() == "true"
+    explicitly_on = _flag_is_true(
+        getenv_or_action("ENABLE_GOVBR_AUTH", action="ignore", default="")
+    )
     if explicitly_on:
         import pytest
 
         pytest.skip("ENABLE_GOVBR_AUTH=true (via env/.env) — habilitado explicitamente")
     assert govbr_auth_gating not in ENABLED_MODULES
+
+
+def test_flag_is_true_tolerates_whitespace_and_case():
+    """Hardening do gate govbr: `getenv_or_action` NÃO faz strip, então um valor
+    com ``\\n``/espaço (comum em paste no Infisical) ou caixa diferente precisa
+    ligar mesmo assim. Opt-in estrito: só ``true`` liga — ``1``/``yes`` não."""
+    from src.prompt_modules import _flag_is_true
+
+    assert _flag_is_true("true")
+    assert _flag_is_true("true\n"), "newline de paste deve ser tolerado"
+    assert _flag_is_true("  TRUE  "), "espaço + caixa devem ser tolerados"
+    assert not _flag_is_true("false")
+    assert not _flag_is_true("")
+    assert not _flag_is_true(None)
+    assert not _flag_is_true("1"), "opt-in estrito: só 'true'"
+    assert not _flag_is_true("yes"), "opt-in estrito: só 'true'"
 
 
 # ---------- módulo vision_inbound ----------


### PR DESCRIPTION
## O que
Hardening do gate `govbr_auth_gating` + observabilidade no decision-point.

## Por que
O gate fazia `.lower() == "true"` **sem `.strip()`**. `getenv_or_action` não faz strip, então um valor com `\n`/espaço (comum em paste no Infisical UI) falhava a checagem e o módulo **não ligava** — 3 deploys em staging com `ENABLE_GOVBR_AUTH=true` não geraram o sufixo `+govbr_auth_gating` no prompt composto.

## Mudança
1. Helper puro `_flag_is_true(raw)` = `raw.strip().lower() == "true"` (opt-in **estrito**: só `true` liga, não `1`/`yes`).
2. Gate captura o raw com `default=""` e usa o helper (backward-compat: unset e `false` seguem OFF; `true` segue ON).
3. `logging.info` no decision-point reporta quais gates opcionais resolveram on/off + **presença** do `ENABLE_GOVBR_AUTH` (bool, **nunca o valor**) → próximo deploy se autodiagnostica: `present=False` ⇒ var não chega (Infisical/projeto); `present=True`+off ⇒ valor != `true`.

## Como testei
- 44 testes verdes; novo `test_flag_is_true_tolerates_whitespace_and_case` (whitespace/caixa/None/estrito).
- Review: Claude code-reviewer (opus) APPROVE; Codex (gpt-5.5 xhigh) executado, sem P1/P2 neste diff.
- Revisão humana: o autor aprova o diff (line-by-line; rodou a suíte).

## Rollback
Reverter o merge (PR via staging). Sem mudança de schema/infra; flag-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)