### PR TITLE
fix(prompt): emite log de gates via loguru (stdlib não era capturado)

### DIFF
--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -28,8 +28,9 @@ agente (tom, escopo, fallbacks). Os módulos cobrem apenas integrações
 específicas que devem viver ao lado do código de tools.
 """
 
-import logging
 from typing import Tuple
+
+from loguru import logger
 
 from src.prompt_modules import (
     audio_inbound,
@@ -149,9 +150,9 @@ if _govbr_auth_enabled:
 # valor) torna o deploy diagnosticável: ``present=False`` => o flag não chegou
 # ao ambiente (problema de Infisical/projeto); ``present=True`` com
 # ``govbr_auth_gating=False`` => valor != "true".
-logging.getLogger(__name__).info(
-    "prompt_modules optional gates: audio_response=%s media_response=%s "
-    "interactive_response=%s govbr_auth_gating=%s (ENABLE_GOVBR_AUTH present=%s)",
+logger.info(
+    "prompt_modules optional gates: audio_response={} media_response={} "
+    "interactive_response={} govbr_auth_gating={} (ENABLE_GOVBR_AUTH present={})",
     _audio_response_enabled,
     _media_response_enabled,
     _interactive_response_enabled,


### PR DESCRIPTION
## O que
Corrige a instrumentação de observabilidade adicionada no #76 pra usar **loguru** em vez de stdlib `logging`.

## Por que
O app loga via loguru (`from loguru import logger`, ver `src/prompt.py`). O log de decisão dos gates do #76 usava `logging.getLogger(__name__).info(...)` com `%s` — **loguru não captura o stdlib logging**, então a linha nunca apareceu no log do deploy (confirmado: outros INFO via loguru aparecem; o meu não). Sem isso, o autodiagnóstico `ENABLE_GOVBR_AUTH present=?` não serve.

## Mudança
- `import logging` → `from loguru import logger`; `logging.getLogger(__name__).info(...)` → `logger.info(...)` com placeholders `{}`. Sem mudança de lógica (mesmos 5 args).

## Como testei
- 44 testes verdes; Claude code-reviewer (opus) APPROVE; Codex (gpt-5.5 xhigh) sem defeito na mudança staged.
- Revisão humana: autor aprova o diff (1 arquivo, troca mecânica de logger).

## Rollback
Reverter o merge (PR via staging). Flag-only, sem schema/infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)