### PR TITLE
feat(prompt): ativa govbr_auth_gating por padrão (opt-out)

### DIFF
--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -110,23 +110,16 @@ _interactive_response_enabled = (
     )
 )
 
-def _flag_is_true(raw: str | None) -> bool:
-    """Normaliza um flag booleano de env. Tolera whitespace (paste no Infisical
-    costuma deixar ``\\n``/espaço no valor) e caixa; só ``"true"`` liga. É mais
-    estrito que os gates ``!= "false"`` acima — auth é opt-in deliberado, então
-    qualquer coisa que não seja exatamente ``true`` (após strip/lower) fica OFF.
-    `getenv_or_action` não faz strip, então a normalização vive aqui."""
-    return (raw or "").strip().lower() == "true"
-
-
-# `govbr_auth_gating` gate: OPT-IN, controlado SÓ por ENABLE_GOVBR_AUTH (default
-# OFF). O flag do operador é o switch único — sem acoplar a MCP_EXCLUDED_TOOLS,
-# que estava bloqueando a habilitação quando as tools govbr aparecem na exclusão
-# por motivo legado. A preocupação de "instruir tool não-bound" é tratada no
-# PRÓPRIO prompt do módulo (instrui o LLM a não chamar uma tool govbr que não
-# esteja disponível), em vez de derrubar o módulo inteiro.
+# `govbr_auth_gating` gate: ATIVADO POR PADRÃO (opt-out), mesmo padrão dos gates
+# acima (``!= "false"``). Antes era opt-in (exigia ENABLE_GOVBR_AUTH=true), mas o
+# flag nunca chegava ao env do DEPLOY: o deploy lê o Infisical em root
+# NÃO-recursivo e a var ficava em subpasta (o runtime k8s, recursivo, a via; o
+# deploy não), então o módulo ficava sempre OFF apesar de ``true`` no UI. Agora
+# liga por padrão; só ``ENABLE_GOVBR_AUTH=false`` explícito desliga (kill-switch
+# em código). A preocupação de "instruir tool não-bound" é tratada no PRÓPRIO
+# prompt do módulo (instrui o LLM a não chamar uma tool govbr indisponível).
 _govbr_auth_raw = _getenv_or_action("ENABLE_GOVBR_AUTH", action="ignore", default="")
-_govbr_auth_enabled = _flag_is_true(_govbr_auth_raw)
+_govbr_auth_enabled = (_govbr_auth_raw or "").strip().lower() != "false"
 
 ENABLED_MODULES = [
     workflow_continuation,
@@ -147,9 +140,10 @@ if _govbr_auth_enabled:
 
 # Observability — os gates opcionais resolvem em import-time e ficam invisíveis
 # fora do sufixo de version. Logar a decisão (+ presença do flag govbr, SEM o
-# valor) torna o deploy diagnosticável: ``present=False`` => o flag não chegou
-# ao ambiente (problema de Infisical/projeto); ``present=True`` com
-# ``govbr_auth_gating=False`` => valor != "true".
+# valor) torna o deploy diagnosticável. Com o opt-out, ``govbr_auth_gating=True``
+# é o esperado mesmo com ``present=False`` (flag ausente → default ON); só
+# ``present=True`` + ``govbr_auth_gating=False`` indica desligamento explícito
+# (ENABLE_GOVBR_AUTH=false).
 logger.info(
     "prompt_modules optional gates: audio_response={} media_response={} "
     "interactive_response={} govbr_auth_gating={} (ENABLE_GOVBR_AUTH present={})",

--- a/tests/unit/test_prompt_modules.py
+++ b/tests/unit/test_prompt_modules.py
@@ -222,39 +222,23 @@ def test_govbr_auth_gating_lists_restricted_and_public_scope():
     assert "anônim" in p, "exceção de zeladoria anônima ausente"
 
 
-def test_govbr_auth_gating_off_by_default():
-    """Default OFF (opt-in): a feature fica DORMENTE até ENABLE_GOVBR_AUTH=true
-    explícito (switch único — desacoplado de MCP_EXCLUDED_TOOLS). Usa o MESMO
-    source que o gate de produção (getenv_or_action lê root .env + os.environ),
-    pra não falhar falsamente quando habilitado via .env. Pula se o ambiente
-    habilita explicitamente."""
-    from src.prompt_modules import _flag_is_true
+def test_govbr_auth_gating_on_by_default():
+    """Default ON (opt-out): o módulo entra em ENABLED_MODULES a menos que
+    ENABLE_GOVBR_AUTH=false explícito. O flag do Infisical não chegava ao env do
+    DEPLOY (root não-recursivo), então o gating é ligado em código; só ``false``
+    explícito desliga. Usa o MESMO source que o gate de produção
+    (getenv_or_action lê root .env + os.environ). Pula se o ambiente desliga
+    explicitamente."""
     from src.utils.infisical import getenv_or_action
 
-    explicitly_on = _flag_is_true(
-        getenv_or_action("ENABLE_GOVBR_AUTH", action="ignore", default="")
-    )
-    if explicitly_on:
+    explicitly_off = (
+        getenv_or_action("ENABLE_GOVBR_AUTH", action="ignore", default="") or ""
+    ).strip().lower() == "false"
+    if explicitly_off:
         import pytest
 
-        pytest.skip("ENABLE_GOVBR_AUTH=true (via env/.env) — habilitado explicitamente")
-    assert govbr_auth_gating not in ENABLED_MODULES
-
-
-def test_flag_is_true_tolerates_whitespace_and_case():
-    """Hardening do gate govbr: `getenv_or_action` NÃO faz strip, então um valor
-    com ``\\n``/espaço (comum em paste no Infisical) ou caixa diferente precisa
-    ligar mesmo assim. Opt-in estrito: só ``true`` liga — ``1``/``yes`` não."""
-    from src.prompt_modules import _flag_is_true
-
-    assert _flag_is_true("true")
-    assert _flag_is_true("true\n"), "newline de paste deve ser tolerado"
-    assert _flag_is_true("  TRUE  "), "espaço + caixa devem ser tolerados"
-    assert not _flag_is_true("false")
-    assert not _flag_is_true("")
-    assert not _flag_is_true(None)
-    assert not _flag_is_true("1"), "opt-in estrito: só 'true'"
-    assert not _flag_is_true("yes"), "opt-in estrito: só 'true'"
+        pytest.skip("ENABLE_GOVBR_AUTH=false (via env/.env) — desligado explicitamente")
+    assert govbr_auth_gating in ENABLED_MODULES
 
 
 # ---------- módulo vision_inbound ----------


### PR DESCRIPTION
## O que
Flipa o gate do `govbr_auth_gating` de **opt-in** (default OFF) para **opt-out** (default ON). Só `ENABLE_GOVBR_AUTH=false` explícito desliga (kill-switch em código).

## Por que
O flag `ENABLE_GOVBR_AUTH` **nunca chegava ao env do DEPLOY**: o deploy lê o Infisical em **root NÃO-recursivo**, e a var ficava numa **subpasta** (o runtime k8s recursivo a via; o deploy não). Resultado: o gate opt-in (#73) deixava o módulo **sempre OFF** apesar de `true` no UI — `present=False` em ~6 deploys consecutivos. O usuário direcionou: **ativar no código**, sem depender do flag.

## Mudança
- Gate vira `(_govbr_auth_raw or "").strip().lower() != "false"` — mesmo padrão `!= "false"` dos gates irmãos (audio/media/interactive_response).
- Remove o helper `_flag_is_true` (dead code após o flip).
- Inverte `test_govbr_auth_gating_off_by_default` → `on_by_default`.
- Mantém o log de observabilidade (presença do flag, sem valor).
- **Reverte o default opt-in do #73** (decisão deliberada, por direção do usuário).

## Como testei
- 43 testes verdes; prova local `compose()` = sufixo `+govbr_auth_gating` presente com env unset.
- Reviews: Claude code-reviewer (opus) APPROVE; Codex (gpt-5.5 xhigh) executado — P2 só em untracked fora do changeset.
- Revisão humana: autor aprova o diff (line-by-line; rodou a suíte).

## Rollback
Reverter o merge (PR via staging), OU setar `ENABLE_GOVBR_AUTH=false` no env do deploy. Flag/prompt-only, sem schema/infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)