### PR TITLE
feat(prompt): comando de encerrar sessão (session_close)

### DIFF
--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -39,6 +39,7 @@ from src.prompt_modules import (
     interactive_response,
     media_inbound,
     media_response,
+    session_close,
     video_inbound,
     vision_inbound,
     workflow_continuation,
@@ -123,6 +124,7 @@ _govbr_auth_enabled = (_govbr_auth_raw or "").strip().lower() != "false"
 
 ENABLED_MODULES = [
     workflow_continuation,
+    session_close,
     media_inbound,
     vision_inbound,
     audio_inbound,

--- a/src/prompt_modules/session_close.py
+++ b/src/prompt_modules/session_close.py
@@ -1,0 +1,61 @@
+"""
+Prompt module — encerramento de atendimento a pedido do cidadão.
+
+Antes deste módulo o bot não tinha um "comando de encerrar": uma conversa só
+terminava por inatividade (TTL no gateway) ou quando o cidadão trocava de
+assunto (pivot tratado em ``workflow_continuation``). Faltava reconhecer a
+intenção explícita de finalizar ("tchau", "era só isso", "pode encerrar") e
+fechar com cordialidade — sem deixar um workflow em aberto no limbo.
+
+Não depende de tool nova: o fechamento é comportamento conversacional. O
+cancelamento de workflow ativo reusa o mesmo mecanismo de
+``workflow_continuation`` (chamar ``multi_step_service`` com sinal de
+cancelamento, ou parar de mantê-lo ativo). O logout gov.br, quando aplicável,
+é tratado pelo módulo ``govbr_auth_gating`` (logout a pedido do cidadão) — não
+duplicado aqui pra não instruir uma tool que pode não estar bound.
+
+Sempre ativo (sem flag): como não chama tool, não há risco de instruir tool
+não-bound — mesmo critério dos módulos ``workflow_continuation`` /
+``media_inbound``.
+"""
+
+MODULE_NAME = "session_close"
+
+MODULE_PROMPT = """\
+## Encerramento de atendimento
+
+Reconheça quando o cidadão quer **encerrar a conversa** e feche com
+cordialidade. Sinais de encerramento (intenção clara de finalizar): "tchau",
+"obrigado, era só isso", "era só isso mesmo", "pode encerrar", "encerrar
+atendimento", "finalizar", "valeu, até mais", "não preciso de mais nada".
+
+### Antes de encerrar
+- **Se houver um workflow `multi_step_service` ativo e ainda incompleto**
+  (aguardando campo ou não submetido), NÃO o descarte em silêncio. Confirme:
+  "Você quer concluir o chamado de *[serviço]* que começamos antes de
+  encerrar, ou prefere cancelar?" Se o cidadão pedir pra cancelar, encerre o
+  workflow (chame `multi_step_service` do workflow ativo com sinal de
+  cancelamento se a tool suporta, ou apenas pare de mantê-lo ativo). Se quiser
+  concluir, retome o workflow normalmente — não encerre ainda.
+- **Se um chamado/protocolo acabou de ser aberto**, confirme o número do
+  protocolo na despedida pra o cidadão sair com o comprovante em mãos.
+- **Cidadão autenticado via gov.br**: o logout (tratado pelo módulo de
+  autenticação) só acontece DEPOIS de resolver a decisão acima de concluir ou
+  cancelar o workflow ativo — nunca desconecte no meio de um atendimento ainda
+  em aberto.
+
+### Como se despedir
+- Curto e humano. Agradeça e deixe claro que ele pode voltar quando quiser, por
+  exemplo: "Prontinho! Qualquer outra coisa, é só me chamar aqui — tô à
+  disposição. 👋"
+- **Não** use frase robótica tipo "Sessão encerrada." nem feche com apenas um
+  acknowledgement seco.
+- Não force perguntas repetidas de "deseja mais alguma coisa?" depois de já ter
+  resolvido — um fechamento caloroso basta.
+
+### Não confunda com resposta de etapa
+Se um workflow estiver aguardando um campo e a mensagem do cidadão **puder ser
+a resposta desse campo** (ex: um endereço, um "sim", um número), priorize
+continuar o workflow (veja a regra de continuação de workflow ativo). Só trate
+como encerramento quando a intenção de finalizar for inequívoca.
+"""

--- a/tests/unit/test_prompt_modules.py
+++ b/tests/unit/test_prompt_modules.py
@@ -13,6 +13,7 @@ from src.prompt_modules import (
     audio_inbound,
     govbr_auth_gating,
     media_inbound,
+    session_close,
     vision_inbound,
     workflow_continuation,
 )
@@ -441,3 +442,67 @@ def test_compose_is_pure_and_idempotent():
     a2, v2 = compose("BASE", "v1")
     assert a1 == a2
     assert v1 == v2
+
+
+# ---------- session_close (encerramento de atendimento) ----------
+
+
+def test_session_close_module_has_required_attributes():
+    """session_close segue o contrato MODULE_NAME/MODULE_PROMPT."""
+    assert hasattr(session_close, "MODULE_NAME")
+    assert hasattr(session_close, "MODULE_PROMPT")
+    assert isinstance(session_close.MODULE_NAME, str)
+    assert isinstance(session_close.MODULE_PROMPT, str)
+
+
+def test_session_close_module_name_is_stable():
+    """MODULE_NAME vira sufixo no version (e em logs OTel) — não pode mudar
+    silenciosamente."""
+    assert session_close.MODULE_NAME == "session_close"
+
+
+def test_session_close_enabled_by_default():
+    """Sempre ativo (sem flag): não chama tool, não há risco de tool não-bound
+    — mesmo critério de workflow_continuation."""
+    assert session_close in ENABLED_MODULES
+
+
+def test_session_close_prompt_recognizes_end_intent():
+    """Guard contra deleção dos gatilhos de encerramento — sem eles o LLM não
+    reconhece a intenção de finalizar."""
+    p = session_close.MODULE_PROMPT.lower()
+    assert "encerrar" in p
+    assert "tchau" in p or "era só isso" in p
+
+
+def test_session_close_prompt_protects_active_workflow():
+    """Encerrar não pode descartar workflow ativo em silêncio: deve confirmar
+    antes de cancelar, reusando o mecanismo de multi_step_service."""
+    p = session_close.MODULE_PROMPT.lower()
+    assert "workflow" in p
+    assert "cancel" in p
+    assert "multi_step_service" in p
+
+
+def test_session_close_defers_field_answer_to_workflow():
+    """Não pode clobberar a regra de continuação: se a mensagem puder ser
+    resposta de um campo, o workflow tem prioridade sobre o encerramento."""
+    p = session_close.MODULE_PROMPT.lower()
+    assert "priorize" in p and "campo" in p
+
+
+def test_session_close_before_media_modules_in_enabled():
+    """Mesma lógica de workflow_continuation: regra conversacional geral entra
+    antes dos módulos de mídia que produzem respostas de etapa."""
+    names = [m.MODULE_NAME for m in ENABLED_MODULES]
+    assert "session_close" in names
+    assert names.index("session_close") < names.index("media_inbound")
+
+
+def test_session_close_logout_after_workflow_resolution():
+    """Precedência (achado de review claude+codex): pra cidadão autenticado, o
+    logout só ocorre DEPOIS de resolver concluir/cancelar o workflow ativo —
+    nunca no meio de um atendimento em aberto."""
+    p = session_close.MODULE_PROMPT.lower()
+    assert "logout" in p
+    assert "depois" in p


### PR DESCRIPTION
## What
New prompt module `session_close` adds an **end-session command** to the WhatsApp citizen bot. Recognizes farewell/close intent ("tchau", "era só isso", "encerrar", "finalizar") and closes the conversation cordially.

## Why
The bot had no way to end a session: a conversation only ended via inactivity TTL (gateway, 24h) or implicit topic-switch (`workflow_continuation`). Citizens (and tomorrow's evaluator) expect to wrap up. This adds explicit, graceful closure.

## How
- New `src/prompt_modules/session_close.py` (MODULE_NAME/MODULE_PROMPT contract), registered in `ENABLED_MODULES` right after `workflow_continuation` (before media modules).
- **Protects an active workflow**: confirms "concluir ou cancelar?" before dropping an in-progress `multi_step_service` workflow (reuses the cancel mechanism from `workflow_continuation` — no new tool).
- **Defers gov.br logout** to the auth module; for authenticated citizens, logout happens only AFTER the workflow concluir/cancelar decision is resolved (precedence rule — addresses a dual-review MEDIUM finding).
- **Defers to `workflow_continuation`** when a message could be a field answer (no clobbering of the active-workflow rule).

## How tested
- `tests/unit/test_prompt_modules.py`: +7 tests (contract, end-intent triggers, workflow protection, field-answer deference, module ordering, logout-after-workflow precedence). Full file: **51 passed**.
- `ruff check` clean; pre-commit `check-mcp-tool-references` passed.
- **Dual review** (claude `code-reviewer` opus + codex) on the final diff: clean; the MEDIUM precedence conflict was resolved before commit.
- Review depth: line-by-line + ran tests.

## Rollback
Pure additive prompt module. To disable: remove `session_close` from `ENABLED_MODULES` in `src/prompt_modules/__init__.py` (no flag needed) and redeploy. No data/schema/tool changes; the composed prompt version suffix simply loses `+session_close`.

## Note (scope)
The gov.br "encerrar → logout" linkage (1 line in `govbr_auth_gating.py`) was deliberately **left out** to avoid a collision with the concurrent gov.br prompt work (another session) editing that same file. Recommend that branch own the one-liner. Authenticated citizens still get logout via the existing "sair/desconectar" triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
