### PR TITLE
fix(prompt): mensagem gov.br mais limpa + regenera link expirado

### DIFF
--- a/src/prompt_modules/govbr_auth_gating.py
+++ b/src/prompt_modules/govbr_auth_gating.py
@@ -13,12 +13,13 @@ que acessam/alteram dado pessoal vinculado ao CPF (multas, IPTU, status de
 processo, dados cadastrais, agendamentos vinculados). Informação pública e
 abertura de chamado de zeladoria anônimo NÃO exigem auth.
 
-Realidade operacional: o callback do Gateway ainda NÃO notifica o WhatsApp de
-volta (TODO no `govbr_callback.go` deployado). Logo o bot não recebe sinal
-automático de "autenticou"; precisa RE-checar ``govbr_auth_status`` na próxima
-mensagem do cidadão e então retomar a ação pendente. Esse protocolo está
-codificado abaixo pra NÃO depender daquele TODO (que exigiria redeploy do
-gateway).
+Realidade operacional (verificado em staging 2026-05-26): o callback do Gateway
+SALVA o token mas ainda NÃO notifica o WhatsApp de volta (TODO em
+``govbr_callback.go``). Logo não há sinal automático de "autenticou" — o cidadão
+manda UMA mensagem curta após o login e o bot RE-checa ``govbr_auth_status`` e
+retoma. Auto-resume de verdade (dispensar a mensagem de retorno) depende de
+implementar esse TODO no Gateway — a infra de ``callback_url``/``previous_message``
+já existe no fluxo de mensagens, falta o callback acioná-la.
 
 Enforcement — LIMITAÇÃO IMPORTANTE: este gating é de ORQUESTRAÇÃO (prompt), NÃO
 uma fronteira de segurança dura. Tool calls na mesma AIMessage executam em
@@ -54,10 +55,10 @@ Alguns serviços exigem **identidade verificada** do cidadão via gov.br (login 
 ### Protocolo (siga exatamente)
 1. **Ao detectar pedido de serviço restrito**, ANTES de executar, chame `govbr_auth_status(user_number=<número do cidadão>)`.
 2. **Se `is_authenticated` e `token_valid` forem verdadeiros** → identidade confirmada; prossiga normalmente com o serviço.
-3. **Se NÃO autenticado** → chame `govbr_auth_init(user_number=<número do cidadão>, service_context="<serviço>")` (identificador curto: `iptu`, `multas`, `processo`, `dados_cadastrais`, `agendamento`). Pegue `auth_url` da resposta e apresente ao cidadão de forma clara e acolhedora, por exemplo:
-   > "Pra [consultar suas multas] preciso confirmar sua identidade no gov.br. Toque no link, faça login e volte aqui que eu continuo: {auth_url}\\n(O link expira em alguns minutos.)"
-   **NÃO execute o serviço restrito** enquanto a identidade não estiver confirmada.
-4. **Quando o cidadão voltar** (qualquer mensagem depois de você enviar o link), **RE-cheque `govbr_auth_status` primeiro** — o sistema NÃO te avisa automaticamente que ele autenticou. Se agora estiver autenticado, **retome a ação pendente** sem pedir tudo de novo. Se ainda não, reforce com gentileza que falta concluir o login pelo link.
+3. **Se NÃO autenticado** → chame `govbr_auth_init(user_number=<número do cidadão>, service_context="<serviço>")` (identificador curto: `iptu`, `multas`, `processo`, `dados_cadastrais`, `agendamento`). Pegue `auth_url` da resposta e apresente o link **uma única vez**, de forma clara e concisa, por exemplo:
+   > "Pra [consultar suas multas] preciso confirmar sua identidade no gov.br. Toque no link e faça o login 👇\\n{auth_url}\\nQuando terminar, é só me dar um \"ok\" aqui que eu sigo de onde paramos. (O link vale só alguns minutos.)"
+   **NÃO** prometa reenviar o link, **NÃO** diga "você vai receber o link novamente", **NÃO** o repita a cada mensagem, **NÃO** use "combinado?", e **NÃO execute o serviço restrito** enquanto a identidade não estiver confirmada.
+4. **Quando o cidadão voltar** (a mensagem dele após o login), **RE-cheque `govbr_auth_status` PRIMEIRO**. Se autenticado, **retome a ação pendente** sem fazê-lo repetir nada e sem pedir login de novo. Se ainda não: reforce com gentileza que falta concluir o login — se o link enviado ainda for recente, reaponte o mesmo (não fique gerando links a cada mensagem); se já **expirou** (vale só alguns minutos) ou o cidadão disser que **não funcionou**, gere um novo com `govbr_auth_init`.
 5. **Logout**: se o cidadão pedir para desconectar, sair, ou "esquecer meus dados", chame `govbr_logout(user_number=<número do cidadão>)` e confirme.
 
 ### Regras


### PR DESCRIPTION
## O que
Limpa a mensagem pós-link do gating gov.br (prompt-only).

## Por que
Após o login, o cidadão recebia uma mensagem confusa ("você vai receber o link novamente... me envie uma mensagem pra continuar. Combinado?"). Esta mudança apresenta o link **uma vez**, concisa, sem "novamente"/"combinado?"/repetição, mantendo um cue de retorno **honesto** ("me dá um ok que eu sigo").

## Importante (correção pós-review)
O **auto-resume NÃO está implementado** no Gateway (o callback só tem `TODO` de notificar o WhatsApp; o que parecia auto-resume era a 2ª mensagem do cidadão). Então este prompt **não** afirma auto-resume — seria stall. O **auto-resume real** é trabalho separado no Gateway (implementar o TODO via a infra `callback_url`/`previous_message` existente).

## Também
Regenera o link quando **expirado/quebrado** (antes ficava preso no link velho).

## Testes
Prompt-only; gating intacto (52 unit + regressão 100% em conteúdo equivalente). Reviews: Claude (opus) APPROVE; Codex (gpt-5.5 xhigh) sem issue de correção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)