### PR TITLE
feat(prompt): catálogo de imagens oficiais — foto da Prefeitura

### DIFF
--- a/src/prompt_modules/media_response.py
+++ b/src/prompt_modules/media_response.py
@@ -56,6 +56,18 @@ Quando o cidadão pedir explicitamente uma resposta em formato não-texto (image
 
 **REGRA #4: location precisa de coordenadas reais.** Não invente lat/lng — use os retornos das tools de equipamentos (`equipments_query`, `find_unidade_de_saude_proxima`, etc.) que retornam lat/lng dos equipamentos públicos. Se você só tem endereço, use a tool `validate_address` primeiro pra geocodar.
 
+### Catálogo de imagens oficiais
+Quando o cidadão pedir explicitamente a foto/imagem de um item OFICIAL deste catálogo, envie a URL correspondente via `send_whatsapp_media(type="image", url=<url do catálogo>)`:
+
+| Assunto pedido pelo cidadão | url |
+|---|---|
+| **Prefeitura** (a sede, o prédio da prefeitura, "foto da prefeitura") | `https://prefeitura.rio/wp-content/uploads/2021/07/51174249347_42fdb1598c_w.jpg` |
+
+Regras do catálogo:
+- Só envie quando o cidadão **pedir explicitamente** aquela foto (a REGRA #1 continua valendo).
+- Para um assunto que **NÃO está no catálogo**, **não invente URL nem busque na web** — responda com honestidade, ex: "Ainda não tenho uma foto oficial de [assunto] cadastrada aqui, mas posso te ajudar com o que precisar."
+- O catálogo cresce com o tempo; use apenas as URLs listadas acima.
+
 ### Exemplo end-to-end
 
 ```


### PR DESCRIPTION
## What
Adds an **official-image catalog** to the `media_response` prompt module so the bot can send a photo of an official subject (e.g., "manda a foto da prefeitura") via the existing `send_whatsapp_media`.

## Why
The bot couldn't send "a foto da prefeitura" — it had no image source for it (it's not a photo search engine). For a **gov bot**, the safe approach is a **curated catalog of official URLs** (no random web images, no AI-generated fakes of real buildings). This seeds the catalog with the Prefeitura's official photo.

## How (prompt text only — `media_response.py`)
- New "Catálogo de imagens oficiais" section: subject → official URL; on explicit request, send via `send_whatsapp_media(type="image", url=...)`.
- Seed entry: **Prefeitura** → `https://prefeitura.rio/wp-content/uploads/2021/07/51174249347_42fdb1598c_w.jpg` (official `prefeitura.rio`; verified live: HTTP 200, image/jpeg, ~60KB — fetchable server-side, so Meta can fetch it).
- Reinforces REGRA #1 (only on explicit request). For **uncatalogued** subjects: do NOT invent a URL or search the web → respond honestly ("ainda não tenho essa foto oficial cadastrada").
- Catalog lives in the prompt (small set; grows over time). When it gets large, move to a data/tool.

## How tested
- `ruff` clean; markdown table well-formed; module contract intact.
- URL verified fetchable (200 image/jpeg) from the cluster (same server-side fetch path Meta uses).
- Dual review (claude opus + codex): both PASS, no issues.
- Review depth: line-by-line.

## Rollback
Revert this commit. Prompt text only; back-compatible (no behavior change for non-photo requests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
