### PR TITLE
feat(prompt): catálogo de vídeos oficiais — compartilha link

### DIFF
--- a/src/prompt_modules/media_response.py
+++ b/src/prompt_modules/media_response.py
@@ -68,6 +68,18 @@ Regras do catálogo:
 - Para um assunto que **NÃO está no catálogo**, **não invente URL nem busque na web** — responda com honestidade, ex: "Ainda não tenho uma foto oficial de [assunto] cadastrada aqui, mas posso te ajudar com o que precisar."
 - O catálogo cresce com o tempo; use apenas as URLs listadas acima.
 
+### Vídeos oficiais (compartilhar link)
+A Prefeitura não tem vídeos em arquivo `.mp4` — eles ficam no YouTube. Por isso, vídeo do catálogo é **compartilhado como LINK em texto** (o WhatsApp gera o preview automaticamente): **NÃO** use `send_whatsapp_media` para esses links (o Meta não busca uma página do YouTube como vídeo). Responda com uma mensagem de texto curta + o link.
+
+| Assunto pedido pelo cidadão | link (enviar como texto, NÃO como mídia) |
+|---|---|
+| **Como solicitar remoção de entulho** / descarte / retirada de entulho (Comlurb / 1746) | https://www.youtube.com/watch?v=3XE2L1lutR4 |
+
+Regras (mesma lógica do catálogo de imagens):
+- Só compartilhe quando o cidadão **pedir explicitamente** o vídeo (a REGRA #1 continua valendo).
+- Assunto **fora do catálogo** → **não invente link nem busque no YouTube** — responda com honestidade: "Ainda não tenho um vídeo oficial sobre [assunto] cadastrado aqui."
+- Exemplo de resposta: "Tem sim! A Prefeitura explica como solicitar a remoção de entulho neste vídeo: https://www.youtube.com/watch?v=3XE2L1lutR4 🎥"
+
 ### Exemplo end-to-end
 
 ```


### PR DESCRIPTION
## What
Extends the official-media catalog (in `media_response` prompt) with **official videos**, shared as a **text link** (YouTube), so the bot can point citizens to official Prefeitura videos.

## Why
The bot couldn't share a Prefeitura video. The Prefeitura has **no direct `.mp4`** — all videos live on YouTube, and a YouTube watch URL **cannot** be sent via `send_whatsapp_media` (Meta fetches a media file, not an HTML page). The right pattern for a gov bot is sharing the **official link as text** (WhatsApp renders the preview/thumbnail) — official, no hosting, no 16MB limit, no rights/format issues.

## How (prompt text only — `media_response.py`)
- New "Vídeos oficiais (compartilhar link)" subsection after the image catalog.
- **Explicitly instructs NOT to use `send_whatsapp_media` for YouTube links** — reply with a short text message + the link.
- Seed entry: "como solicitar remoção de entulho" → official #ComoFaz video `https://www.youtube.com/watch?v=3XE2L1lutR4`.
- Same rules as the image catalog: only on explicit request; uncatalogued → don't invent/search, respond honestly.

## How tested
- `ruff` clean; markdown well-formed; module contract intact.
- **Video verified via YouTube oEmbed**: public + channel = "Prefeitura do Rio de Janeiro" (@Prefeitura_Rio, official).
- Dual review (claude opus + codex): both PASS; the critical instruction (no `send_whatsapp_media` for YouTube) confirmed unambiguous.

## Rollback
Revert this commit. Prompt text only; back-compatible.

## Note (below-threshold polish, both reviewers)
The generic media table row "Manda um vídeo explicando | video | url" could get a one-clause cross-reference to this section to fully remove latent tension; residual risk is low (the don't-invent rule + the specific catalog section cover it). Optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
