### PR TITLE
feat(audio): modo áudio contínuo durável (preferência persiste entre turnos)

### DIFF
--- a/engine/agent.py
+++ b/engine/agent.py
@@ -38,6 +38,7 @@ from vertexai.agent_engines import (
 # from langgraph.prebuilt import create_react_agent
 # use custom graph without _validate_chat_history
 from engine.custom_react_agent import create_react_agent
+from engine.audio_mode import inject_audio_directive
 from engine.log import logger
 
 # Error monitoring utilities (safe fallback if not available)
@@ -1010,7 +1011,13 @@ class Agent(AsyncQueryable, AsyncStreamQueryable, Queryable, StreamQueryable):
         else:
             # No filtering applied, just inject thread_id normally
             final_state = self._inject_thread_id_in_user_id_params(filtered_state, config)
-        
+
+        # Step 4.5: Modo áudio contínuo — reinjeta a diretiva todo turno, derivada
+        # determinísticamente do histórico persistido (durável via checkpointer).
+        # Entra só em llm_input_messages (não-persistente), igual ao filtro de
+        # curto prazo. Antes do Step 5 para o token counting incluir a diretiva.
+        final_state = inject_audio_directive(state, final_state)
+
         # Step 5: Store the messages that will be sent to LLM for token counting later
         # The prompt_runnable will prepend system prompt to these messages
         if "llm_input_messages" in final_state:

--- a/engine/audio_mode.py
+++ b/engine/audio_mode.py
@@ -1,0 +1,154 @@
+"""Modo áudio contínuo — preferência durável derivada do histórico.
+
+O cidadão pode pedir para receber as respostas **sempre** em áudio (preferência
+contínua) ou voltar para texto. O Engine não tem um store de configuração por
+usuário, então a preferência é derivada **deterministicamente** do histórico de
+conversa persistido (a diretiva mais recente vence) e **reinjetada todo turno**
+no input do LLM pelo ``pre_model_hook`` do agente.
+
+Por que assim:
+- **Durável**: o checkpointer já persiste as mensagens, então a diretiva
+  sobrevive entre turnos sem precisar de um campo novo no schema de estado.
+- **Confiável**: a diretiva é reaplicada a cada turno (não depende do LLM
+  "lembrar" de uma instrução antiga), e a injeção é determinística, não
+  inferência do modelo.
+- **Não-persistente**: a diretiva entra só em ``llm_input_messages`` (o canal
+  que o agente usa para o input do LLM sem gravar no histórico), igual ao
+  filtro de memória de curto prazo.
+
+Distinção importante: um pedido pontual ("me responde com áudio") **não** liga o
+modo contínuo — isso é tratado por turno pelo prompt module ``audio_response``.
+O modo contínuo só liga com marcadores de continuidade ("sempre", "fica",
+"continua", "só áudio", "não precisa escrever").
+"""
+
+import re
+import unicodedata
+from typing import Any, Mapping, Sequence
+
+from langchain_core.messages import HumanMessage, SystemMessage
+
+# Diretiva reinjetada todo turno quando o modo contínuo está ligado. Já embute a
+# regra de precedência (resumo falado em áudio + detalhes em texto) para resolver
+# o conflito com a regra "conteúdo estruturado vai em texto" do prompt module.
+AUDIO_MODE_DIRECTIVE = (
+    "MODO ÁUDIO CONTÍNUO ATIVO. O cidadão pediu para receber as respostas SEMPRE "
+    "em áudio até pedir o contrário. Neste turno: componha a resposta em texto "
+    "natural (sem markdown nem emoji) e chame a tool "
+    "generate_audio_response(text=<resposta>), anexando o audio_base64. "
+    "Se a resposta for longa ou tiver dados estruturados (lista rua-por-rua, "
+    "números de protocolo, links), NÃO caia só para texto: mande o ÁUDIO de um "
+    "resumo falado curto E mantenha os detalhes no texto. Só pare de gerar áudio "
+    "quando o cidadão pedir explicitamente (ex.: 'volta pra texto')."
+)
+
+# Padrões normalizados (sem acento, minúsculo). OFF é checado antes de ON por
+# mensagem, e os conjuntos são disjuntos por construção (ver testes).
+_ON_PATTERNS = [
+    r"sempre.{0,15}(audio|falando|voz|fala\b)",
+    r"(audio|falando|voz).{0,15}sempre",
+    r"(fica|ficar|continua|continuar|deixa).{0,15}(no |em |de )?(audio|falando|voz)",
+    r"\bso\b.{0,6}(audio|voz|falando)",
+    r"tudo.{0,10}(audio|voz|falando)",
+    r"nao precisa.{0,12}escrever",
+    r"para de escrever",
+    r"(responde|responda|me responde|fala).{0,15}sempre.{0,15}(falando|audio|voz)",
+]
+
+_OFF_PATTERNS = [
+    r"volta.{0,15}(texto|escrev|escrit|ler)",
+    r"(para|parar|chega|pode parar|desliga|cancela).{0,10}(de |com |o )?audio",
+    r"sem audio",
+    r"nao precisa.{0,12}audio",
+    r"(manda|responde|responda|prefiro|quero).{0,15}(texto|escrito|escrevendo|por escrito)",
+    r"prefiro ler",  # "ler" só como OFF explícito — evita casar "quero ler o edital"
+    r"escreve (ai|pra mim|aqui)",
+    r"pode escrever",
+]
+
+_ON_RE = [re.compile(p) for p in _ON_PATTERNS]
+_OFF_RE = [re.compile(p) for p in _OFF_PATTERNS]
+
+
+def _normalize(text: str) -> str:
+    """Minúsculo + sem acentos, para casar frases independente de grafia."""
+    decomposed = unicodedata.normalize("NFKD", text)
+    stripped = "".join(c for c in decomposed if not unicodedata.combining(c))
+    return stripped.lower()
+
+
+def _message_text(message: Any) -> str:
+    """Extrai o texto de uma mensagem (str ou lista de blocos)."""
+    content = getattr(message, "content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, Mapping) and isinstance(block.get("text"), str):
+                parts.append(block["text"])
+        return " ".join(parts)
+    return str(content) if content is not None else ""
+
+
+def _is_human(message: Any) -> bool:
+    if isinstance(message, HumanMessage):
+        return True
+    # Tolera dicts/objetos com role/type "human"/"user" (robustez a serialização).
+    role = getattr(message, "type", None) or getattr(message, "role", None)
+    if role is None and isinstance(message, Mapping):
+        role = message.get("type") or message.get("role")
+    return role in ("human", "user")
+
+
+def derive_audio_mode(messages: Sequence[Any]) -> bool:
+    """Deriva o modo áudio contínuo do histórico (diretiva mais recente vence).
+
+    Varre as mensagens do cidadão da mais nova para a mais antiga. A primeira que
+    casar uma diretiva decide: OFF (voltar a texto) → ``False``; ON (sempre áudio)
+    → ``True``. Sem diretiva → ``False`` (texto é o default).
+
+    Por mensagem, OFF é avaliado antes de ON; os conjuntos são disjuntos, então a
+    ordem só importa em mensagens contraditórias (raro), onde texto vence por
+    segurança.
+    """
+    for message in reversed(list(messages)):
+        if not _is_human(message):
+            continue
+        text = _normalize(_message_text(message))
+        if not text:
+            continue
+        if any(rx.search(text) for rx in _OFF_RE):
+            return False
+        if any(rx.search(text) for rx in _ON_RE):
+            return True
+    return False
+
+
+def audio_mode_directive_message() -> SystemMessage:
+    """SystemMessage com a diretiva de modo áudio contínuo (reinjetada por turno)."""
+    return SystemMessage(content=AUDIO_MODE_DIRECTIVE)
+
+
+def inject_audio_directive(state: Mapping[str, Any], final_state: dict) -> dict:
+    """Anexa a diretiva de áudio ao input do LLM quando o modo contínuo está ON.
+
+    Pura e idempotente por turno. Lê a preferência do histórico **persistido**
+    (``state['messages']`` — completo, não o filtrado), e injeta a diretiva no
+    canal não-persistente ``llm_input_messages``, preservando qualquer
+    transformação anterior (memória, filtro, thread_id) já aplicada em
+    ``final_state``. Não mexe em ``messages`` (o canal persistido).
+    """
+    if not derive_audio_mode(state.get("messages", [])):
+        return final_state
+
+    base = final_state.get("llm_input_messages")
+    if base is None:
+        base = final_state.get("messages") or list(state.get("messages", []))
+
+    return {
+        **final_state,
+        "llm_input_messages": [*base, audio_mode_directive_message()],
+    }

--- a/src/prompt_modules/audio_response.py
+++ b/src/prompt_modules/audio_response.py
@@ -10,10 +10,13 @@ intent e:
 3. Anexar o ``audio_base64`` retornado à resposta final, como campo
    adicional além do texto (Mule consome via callback).
 
-A preferência por áudio NÃO é persistida automaticamente — cada pedido
-do cidadão por áudio gera uma resposta em áudio APENAS naquele turno.
-Se ele quiser modo contínuo, ele dirá "fica em áudio sempre" e o LLM
-deve continuar gerando áudio até receber "volta pra texto".
+Um pedido pontual ("me responda com áudio") gera áudio APENAS naquele
+turno. Já o modo CONTÍNUO ("fica em áudio sempre", "não precisa
+escrever") é persistido de forma durável: o ``engine/audio_mode.py``
+deriva a preferência do histórico e reinjeta a diretiva ``MODO ÁUDIO
+CONTÍNUO ATIVO`` no input do LLM a cada turno, até o cidadão pedir
+"volta pra texto". Quando essa diretiva estiver presente, ela é
+autoritativa e tem precedência sobre as exceções do item 4.
 
 Kill switch: ``ENABLE_TTS_ADDENDUM=false`` no MCP env desliga registro
 da tool E o conteúdo deste módulo (o LLM não verá a instrução de
@@ -39,11 +42,12 @@ Quando o cidadão pedir explicitamente a resposta em áudio (ex: "responda por �
 3. **Modo contínuo vs único turno:**
    - Default: gere áudio APENAS no turno em que o cidadão pediu. Próximo turno volta pra texto.
    - Se o cidadão explicitar continuidade ("fica em áudio sempre", "continua falando", "não precisa mais escrever"), continue gerando áudio nos próximos turnos até receber sinal contrário ("volta pra texto", "desliga áudio", "escreve aí").
+   - **Reforço determinístico:** quando o modo contínuo estiver ligado, o sistema injeta a diretiva `MODO ÁUDIO CONTÍNUO ATIVO` neste turno. Trate-a como autoritativa: gere áudio mesmo que você não veja o pedido original no histórico visível (ele pode ter saído da janela de contexto).
 
 4. **NÃO chame `generate_audio_response` quando:**
    - Cidadão não pediu (texto é o default).
    - A resposta é um ack curto (<10 palavras) tipo "Ok!", "Obrigado!", "Tudo certo!" — desperdiça quota TTS pra fala de 1s.
-   - A resposta tem dados estruturados que o cidadão precisa ler (lista de opções numeradas do `multi_step_service`, URLs, números de protocolo). Texto é melhor.
+   - A resposta tem dados estruturados que o cidadão precisa ler (lista de opções numeradas do `multi_step_service`, URLs, números de protocolo). Texto é melhor. **Exceção — modo áudio contínuo ligado:** não caia só pra texto. Mande o ÁUDIO de um resumo falado curto E mantenha os dados estruturados/links no texto. O cidadão recebe os dois.
    - A resposta tem código, comandos ou termos técnicos que TTS pronuncia mal. Texto é melhor.
 
 ### Estilo PT-BR pra TTS

--- a/tests/unit/test_audio_mode.py
+++ b/tests/unit/test_audio_mode.py
@@ -1,0 +1,178 @@
+"""Testes do modo áudio contínuo (engine/audio_mode.py)."""
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+from engine.audio_mode import (
+    AUDIO_MODE_DIRECTIVE,
+    audio_mode_directive_message,
+    derive_audio_mode,
+    inject_audio_directive,
+)
+
+
+def _h(text):
+    return HumanMessage(content=text)
+
+
+# --------------------------------------------------------------------------- #
+# derive_audio_mode — ON
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "text",
+    [
+        "fica em áudio sempre",
+        "responde sempre em áudio",
+        "sempre em audio",  # sem acento
+        "pode continuar falando",
+        "continua no áudio por favor",
+        "quero tudo em áudio",
+        "só áudio daqui pra frente",
+        "não precisa mais escrever, pode falar",
+        "para de escrever, manda só falado",
+        "me responde sempre falando",
+    ],
+)
+def test_on_phrases(text):
+    assert derive_audio_mode([_h(text)]) is True
+
+
+# --------------------------------------------------------------------------- #
+# derive_audio_mode — OFF / não-contínuo
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "text",
+    [
+        "volta pra texto",
+        "volta a escrever",
+        "para de áudio",
+        "desliga o audio",
+        "chega de áudio",
+        "sem áudio agora",
+        "não precisa de áudio",
+        "prefiro ler",
+        "manda por texto",
+        "responde escrevendo",
+        "pode escrever",
+        "escreve aí",
+    ],
+)
+def test_off_phrases(text):
+    assert derive_audio_mode([_h(text)]) is False
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "me responda com áudio",  # pedido pontual, NÃO contínuo
+        "manda um áudio dessa resposta",
+        "como abro um chamado de luminária?",
+        "bom dia",
+        "",
+    ],
+)
+def test_one_shot_or_neutral_is_off(text):
+    """Pedido pontual ou sem diretiva → texto (default)."""
+    assert derive_audio_mode([_h(text)]) is False
+
+
+def test_empty_history_is_off():
+    assert derive_audio_mode([]) is False
+
+
+# --------------------------------------------------------------------------- #
+# Mais recente vence
+# --------------------------------------------------------------------------- #
+def test_newest_directive_wins_off_after_on():
+    history = [_h("fica sempre em áudio"), _h("agora volta pra texto")]
+    assert derive_audio_mode(history) is False
+
+
+def test_newest_directive_wins_on_after_off():
+    history = [_h("volta pra texto"), _h("não, fica sempre em áudio")]
+    assert derive_audio_mode(history) is True
+
+
+def test_intervening_neutral_messages_dont_reset():
+    history = [
+        _h("fica sempre em áudio"),
+        _h("qual o horário do posto?"),
+        _h("e a vacina da gripe?"),
+    ]
+    assert derive_audio_mode(history) is True
+
+
+def test_content_request_with_ler_does_not_disable_audio():
+    """'quero ler o edital' é pedido de conteúdo, não troca de formato — não desliga áudio."""
+    history = [_h("fica sempre em áudio"), _h("quero ler o edital de licitação")]
+    assert derive_audio_mode(history) is True
+
+
+# --------------------------------------------------------------------------- #
+# Robustez: ignora mensagens não-humanas
+# --------------------------------------------------------------------------- #
+def test_ignores_non_human_messages():
+    history = [
+        _h("fica sempre em áudio"),
+        AIMessage(content="Claro, vou responder em áudio sempre."),
+        SystemMessage(content="MODO ÁUDIO CONTÍNUO ATIVO ..."),
+    ]
+    # Só a HumanMessage conta; AIMessage/SystemMessage com "áudio" não viram OFF/ON.
+    assert derive_audio_mode(history) is True
+
+
+def test_list_content_blocks_are_read():
+    msg = HumanMessage(content=[{"type": "text", "text": "fica sempre em áudio"}])
+    assert derive_audio_mode([msg]) is True
+
+
+# --------------------------------------------------------------------------- #
+# Diretiva
+# --------------------------------------------------------------------------- #
+def test_directive_is_system_message():
+    msg = audio_mode_directive_message()
+    assert isinstance(msg, SystemMessage)
+    assert "MODO ÁUDIO CONTÍNUO ATIVO" in msg.content
+    assert msg.content == AUDIO_MODE_DIRECTIVE
+
+
+# --------------------------------------------------------------------------- #
+# inject_audio_directive
+# --------------------------------------------------------------------------- #
+def test_inject_appends_when_on_with_llm_input_messages():
+    state = {"messages": [_h("fica sempre em áudio")]}
+    base = [_h("fica sempre em áudio")]
+    final_state = {"llm_input_messages": list(base), "extra": 1}
+
+    out = inject_audio_directive(state, final_state)
+
+    assert out["extra"] == 1
+    assert len(out["llm_input_messages"]) == len(base) + 1
+    assert isinstance(out["llm_input_messages"][-1], SystemMessage)
+    assert "MODO ÁUDIO CONTÍNUO ATIVO" in out["llm_input_messages"][-1].content
+
+
+def test_inject_creates_llm_input_from_messages_when_absent():
+    state = {"messages": [_h("não precisa mais escrever")]}
+    final_state = {"messages": [_h("não precisa mais escrever")]}
+
+    out = inject_audio_directive(state, final_state)
+
+    assert "llm_input_messages" in out
+    assert isinstance(out["llm_input_messages"][-1], SystemMessage)
+    # messages (canal persistido) não ganha a diretiva
+    assert all(
+        not isinstance(m, SystemMessage)
+        or "MODO ÁUDIO CONTÍNUO" not in getattr(m, "content", "")
+        for m in out["messages"]
+    )
+
+
+def test_inject_noop_when_off():
+    state = {"messages": [_h("volta pra texto")]}
+    final_state = {"llm_input_messages": [_h("volta pra texto")]}
+
+    out = inject_audio_directive(state, final_state)
+
+    assert out is final_state  # inalterado
+    assert len(out["llm_input_messages"]) == 1


### PR DESCRIPTION
## Problema

O cidadão pede "sempre responda em áudio" e o bot volta a texto no turno seguinte. Investigado nos logs (tráfego real) + no prompt module `audio_response`:

- A decisão de áudio era **100% prompt-driven por turno, sem estado durável** — o modo contínuo dependia do LLM lembrar de uma instrução de turnos atrás (frágil, quebra em turnos complexos com tool-use).
- A regra "conteúdo estruturado/longo vai em texto" do `audio_response` **sobrescrevia silenciosamente** a preferência permanente (ex.: pergunta que pede "resumo rua-por-rua" voltava a texto mesmo com "sempre em áudio" ativo).

## Solução (durável, sem cirurgia no schema de estado)

- **`engine/audio_mode.py`** (novo): `derive_audio_mode(messages)` deriva o modo contínuo do **histórico persistido** (diretiva mais recente vence; ON = "sempre/fica/continua em áudio", "não precisa escrever"; OFF = "volta pra texto", "para de áudio"…). Pedido pontual ("me responda com áudio") **não** liga o modo contínuo. `inject_audio_directive(state, final_state)` anexa a diretiva só em `llm_input_messages`.
- **`engine/agent.py`**: `_combined_pre_model_hook` reinjeta a diretiva `MODO ÁUDIO CONTÍNUO ATIVO` **todo turno**, no canal não-persistente `llm_input_messages` (mesmo mecanismo do filtro de curto prazo). Determinístico — não depende da memória do LLM.
- **`src/prompt_modules/audio_response.py`**: precedência explícita — em modo contínuo, conteúdo longo/estruturado vira **áudio do resumo + texto dos detalhes** (não cai só pra texto).

## Por que é seguro

A diretiva entra só em `llm_input_messages`, que `custom_react_agent._get_model_input_state` lê como input do LLM mas **nenhum nó retorna** — então **não vaza pro checkpointer** nem acumula entre turnos. `messages` (canal persistido) não é tocado. Derivar a preferência do histórico (que o checkpointer já guarda) dá durabilidade sem campo novo no estado.

## Testes

- `tests/unit/test_audio_mode.py` (novo): **38 testes** — detector ON/OFF/one-shot/mais-recente-vence/acento-insensível/não-humano/conteúdo-com-"ler" + injeção (anexa/noop/preserva transforms/não-persiste).
- Testes existentes de prompt modules (**51**) seguem verdes.

## Revisão

Revisado por code-reviewer (Opus) — aprovado. Único achado (falso-positivo "quero ler o edital" desligava áudio) corrigido apertando o padrão OFF de "ler".

## Verificação pendente (pós-merge/deploy)

Teste em device real: cidadão diz "sempre em áudio", manda pergunta pesada (turno longo), confirma que vem áudio (resumo) + texto (detalhes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
