### PR TITLE
chore(audio): enxuga prompt estático do audio_response (recupera ~tokens do #85)

### DIFF
--- a/src/prompt_modules/audio_response.py
+++ b/src/prompt_modules/audio_response.py
@@ -42,12 +42,12 @@ Quando o cidadão pedir explicitamente a resposta em áudio (ex: "responda por �
 3. **Modo contínuo vs único turno:**
    - Default: gere áudio APENAS no turno em que o cidadão pediu. Próximo turno volta pra texto.
    - Se o cidadão explicitar continuidade ("fica em áudio sempre", "continua falando", "não precisa mais escrever"), continue gerando áudio nos próximos turnos até receber sinal contrário ("volta pra texto", "desliga áudio", "escreve aí").
-   - **Reforço determinístico:** quando o modo contínuo estiver ligado, o sistema injeta a diretiva `MODO ÁUDIO CONTÍNUO ATIVO` neste turno. Trate-a como autoritativa: gere áudio mesmo que você não veja o pedido original no histórico visível (ele pode ter saído da janela de contexto).
+   - Quando o sistema injetar a diretiva `MODO ÁUDIO CONTÍNUO ATIVO`, trate-a como autoritativa — ela traz as regras de precedência deste turno.
 
 4. **NÃO chame `generate_audio_response` quando:**
    - Cidadão não pediu (texto é o default).
    - A resposta é um ack curto (<10 palavras) tipo "Ok!", "Obrigado!", "Tudo certo!" — desperdiça quota TTS pra fala de 1s.
-   - A resposta tem dados estruturados que o cidadão precisa ler (lista de opções numeradas do `multi_step_service`, URLs, números de protocolo). Texto é melhor. **Exceção — modo áudio contínuo ligado:** não caia só pra texto. Mande o ÁUDIO de um resumo falado curto E mantenha os dados estruturados/links no texto. O cidadão recebe os dois.
+   - A resposta tem dados estruturados que o cidadão precisa ler (lista de opções numeradas do `multi_step_service`, URLs, números de protocolo). Texto é melhor. (Em modo áudio contínuo, a diretiva injetada sobrescreve isto — ver item 3.)
    - A resposta tem código, comandos ou termos técnicos que TTS pronuncia mal. Texto é melhor.
 
 ### Estilo PT-BR pra TTS


### PR DESCRIPTION
## O que

Condensa os dois bullets que o PR #85 adicionou ao `MODULE_PROMPT` estático do `audio_response` (reforço do modo contínuo na Regra 3 + exceção de precedência na Regra 4). **−244 chars** no prompt enviado todo turno.

## Por que

A diretiva dinâmica `MODO ÁUDIO CONTÍNUO ATIVO` (`engine/audio_mode.py`), injetada por turno **só quando o modo está ligado**, já carrega a instrução operativa (chamar `generate_audio_response`) **e** a precedência (conteúdo longo/estruturado → áudio do resumo + texto dos detalhes). Logo o texto estático era redundante e pesava em **todo turno**, inclusive com áudio desligado.

A eval do #85 reprovou por `token_usage_total +10,23%` — majoritariamente regressão **acumulada** de ~11 PRs (issue #86), mas a parte deste módulo (~100 tokens/turno) é recuperável sem perder função. Isto reduz o footprint próprio antes do re-baseline da eval.

## Mantido (sem perda de comportamento)

- Regra 3: ponteiro curto — "trate a diretiva injetada como autoritativa".
- Regra 4: nota de 1 linha apontando pro item 3.
- Comportamento idêntico: a diretiva runtime continua resolvendo tudo quando o modo está ON.

## Testes

89 verdes (`test_prompt_modules` + `test_audio_mode`). Code-reviewer (Opus) aprovado — confirmou que a diretiva carrega ambas as instruções e que não há referência pendente.

Refs: #85 (origem), #86 (regressão acumulada).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
