### PR TITLE
fix(session): reset real de sessão ao encerrar (corrige áudio que vazava)

### DIFF
--- a/engine/agent.py
+++ b/engine/agent.py
@@ -39,6 +39,7 @@ from vertexai.agent_engines import (
 # use custom graph without _validate_chat_history
 from engine.custom_react_agent import create_react_agent
 from engine.audio_mode import inject_audio_directive
+from engine.session_boundary import apply_session_reset
 from engine.log import logger
 
 # Error monitoring utilities (safe fallback if not available)
@@ -1012,8 +1013,14 @@ class Agent(AsyncQueryable, AsyncStreamQueryable, Queryable, StreamQueryable):
             # No filtering applied, just inject thread_id normally
             final_state = self._inject_thread_id_in_user_id_params(filtered_state, config)
 
+        # Step 4.4: Reset de sessão — se o cidadão encerrou ("tchau"/"pode
+        # encerrar") e mandou nova mensagem depois, trunca o llm_input pro
+        # atendimento atual (contexto fresco; memória de longo prazo preservada).
+        # Antes do áudio pra a preferência derivar só da sessão nova.
+        final_state = apply_session_reset(state, final_state)
+
         # Step 4.5: Modo áudio contínuo — reinjeta a diretiva todo turno, derivada
-        # determinísticamente do histórico persistido (durável via checkpointer).
+        # determinísticamente do atendimento atual (reseta após encerramento).
         # Entra só em llm_input_messages (não-persistente), igual ao filtro de
         # curto prazo. Antes do Step 5 para o token counting incluir a diretiva.
         final_state = inject_audio_directive(state, final_state)

--- a/engine/audio_mode.py
+++ b/engine/audio_mode.py
@@ -23,10 +23,12 @@ O modo contínuo só liga com marcadores de continuidade ("sempre", "fica",
 """
 
 import re
-import unicodedata
 from typing import Any, Mapping, Sequence
 
-from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.messages import SystemMessage
+
+from engine.session_boundary import current_session_messages
+from engine.text_match import is_human, message_text, normalize
 
 # Diretiva reinjetada todo turno quando o modo contínuo está ligado. Já embute a
 # regra de precedência (resumo falado em áudio + detalhes em texto) para resolver
@@ -70,39 +72,6 @@ _ON_RE = [re.compile(p) for p in _ON_PATTERNS]
 _OFF_RE = [re.compile(p) for p in _OFF_PATTERNS]
 
 
-def _normalize(text: str) -> str:
-    """Minúsculo + sem acentos, para casar frases independente de grafia."""
-    decomposed = unicodedata.normalize("NFKD", text)
-    stripped = "".join(c for c in decomposed if not unicodedata.combining(c))
-    return stripped.lower()
-
-
-def _message_text(message: Any) -> str:
-    """Extrai o texto de uma mensagem (str ou lista de blocos)."""
-    content = getattr(message, "content", "")
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts = []
-        for block in content:
-            if isinstance(block, str):
-                parts.append(block)
-            elif isinstance(block, Mapping) and isinstance(block.get("text"), str):
-                parts.append(block["text"])
-        return " ".join(parts)
-    return str(content) if content is not None else ""
-
-
-def _is_human(message: Any) -> bool:
-    if isinstance(message, HumanMessage):
-        return True
-    # Tolera dicts/objetos com role/type "human"/"user" (robustez a serialização).
-    role = getattr(message, "type", None) or getattr(message, "role", None)
-    if role is None and isinstance(message, Mapping):
-        role = message.get("type") or message.get("role")
-    return role in ("human", "user")
-
-
 def derive_audio_mode(messages: Sequence[Any]) -> bool:
     """Deriva o modo áudio contínuo do histórico (diretiva mais recente vence).
 
@@ -115,9 +84,9 @@ def derive_audio_mode(messages: Sequence[Any]) -> bool:
     segurança.
     """
     for message in reversed(list(messages)):
-        if not _is_human(message):
+        if not is_human(message):
             continue
-        text = _normalize(_message_text(message))
+        text = normalize(message_text(message))
         if not text:
             continue
         if any(rx.search(text) for rx in _OFF_RE):
@@ -135,13 +104,14 @@ def audio_mode_directive_message() -> SystemMessage:
 def inject_audio_directive(state: Mapping[str, Any], final_state: dict) -> dict:
     """Anexa a diretiva de áudio ao input do LLM quando o modo contínuo está ON.
 
-    Pura e idempotente por turno. Lê a preferência do histórico **persistido**
-    (``state['messages']`` — completo, não o filtrado), e injeta a diretiva no
-    canal não-persistente ``llm_input_messages``, preservando qualquer
-    transformação anterior (memória, filtro, thread_id) já aplicada em
-    ``final_state``. Não mexe em ``messages`` (o canal persistido).
+    Pura e idempotente por turno. Lê a preferência só do atendimento ATUAL
+    (``current_session_messages`` — reseta após um encerramento), e injeta a
+    diretiva no canal não-persistente ``llm_input_messages``, preservando
+    qualquer transformação anterior (memória, filtro, thread_id, reset de
+    sessão) já aplicada em ``final_state``. Não mexe em ``messages`` (o canal
+    persistido).
     """
-    if not derive_audio_mode(state.get("messages", [])):
+    if not derive_audio_mode(current_session_messages(state.get("messages", []))):
         return final_state
 
     base = final_state.get("llm_input_messages")

--- a/engine/session_boundary.py
+++ b/engine/session_boundary.py
@@ -1,0 +1,115 @@
+"""Boundary de sessão — reset real do atendimento ao encerrar.
+
+O módulo de prompt ``session_close`` faz o bot se despedir, mas é puramente
+conversacional: não reseta estado nenhum. Como o ``thread_id`` é o telefone
+(fixo) e o checkpointer persiste tudo, a conversa seguinte continua o MESMO
+thread — então preferências (ex.: modo áudio contínuo), contexto e workflow
+"vazam" pro próximo atendimento mesmo depois de um "encerrar".
+
+Este módulo dá um reset **comportamental** determinístico, no Engine, sem
+tocar Gateway nem deletar Postgres:
+
+- ``detect_close_intent`` reconhece a intenção clara de encerrar (conservador —
+  prefere não detectar a detectar errado, pra nunca apagar contexto no meio de
+  uma conversa por engano).
+- ``current_session_messages`` devolve só as mensagens do atendimento ATUAL —
+  ou seja, a partir da primeira mensagem do cidadão DEPOIS do último
+  encerramento já respondido. O ``pre_model_hook`` usa isso pra truncar o
+  ``llm_input_messages`` (canal não-persistente) e o ``audio_mode`` deriva a
+  preferência só dessa fatia. Resultado: depois de "tchau", a próxima mensagem
+  começa limpa (contexto + áudio resetados); a memória de longo prazo (injetada
+  à parte como SystemMessage) persiste por design.
+
+Reset "duro" (rotacionar thread_id no Gateway + limpar checkpoints) fica como
+follow-up — resolve também o crescimento de storage do thread.
+"""
+
+import re
+from typing import Any, List, Mapping, Sequence
+
+from langchain_core.messages import SystemMessage
+
+from engine.text_match import is_human, message_text, normalize
+
+# Sinais de encerramento (normalizados, sem acento). Conservador de propósito:
+# frases claras de "acabou", não meras gratidões ("obrigado"/"valeu" sozinhos),
+# pra evitar falso-positivo que truncaria contexto no meio do atendimento.
+# Substantivos que tornam "encerrar X" um PEDIDO DE SERVIÇO, não fim de sessão
+# (ex.: "quero encerrar minha conta de luz" / "vou encerrar a matrícula"). O
+# padrão de "encerrar" abaixo usa negative-lookahead pra NÃO casar esses casos.
+_SERVICE_NOUNS = (
+    r"conta|contrato|matricula|inscricao|cadastro|plano|empresa|negocio|mei|"
+    r"servico|chamado|protocolo|pedido|solicitacao|assinatura|beneficio|linha|"
+    r"cartao|divida|debito|parcelamento"
+)
+_CLOSE_PATTERNS = [
+    r"\btchau\b",
+    r"era so isso",
+    r"so isso mesmo",
+    # "encerrar" como fim de atendimento ("pode encerrar", "quero encerrar",
+    # "encerrar atendimento/conversa"), mas NÃO "encerrar <serviço>".
+    rf"\bencerrar\b(?!\s+(a |o |um |uma |uns |umas |minha |meu |meus |minhas |esse |este |essa |esta )*({_SERVICE_NOUNS}))",
+    r"finalizar (o |a )?atendimento",
+    r"\bate (mais|logo|a proxima|breve)\b",
+    # "não preciso de mais nada" como fim, mas não "...nada além do boleto".
+    r"nao preciso (de )?mais nada(?!\s+(alem|que|fora|exceto|a nao ser|so))",
+    r"nao preciso de mais ajuda",
+]
+_CLOSE_RE = [re.compile(p) for p in _CLOSE_PATTERNS]
+
+
+def detect_close_intent(text: str) -> bool:
+    """True quando o texto do cidadão sinaliza encerrar o atendimento."""
+    norm = normalize(text)
+    return bool(norm) and any(rx.search(norm) for rx in _CLOSE_RE)
+
+
+def current_session_messages(messages: Sequence[Any]) -> List[Any]:
+    """Mensagens do atendimento ATUAL (após o último encerramento já respondido).
+
+    Um encerramento "completo" é uma mensagem do cidadão com intenção de fechar
+    que **já foi seguida** por uma nova mensagem do cidadão (o próximo
+    atendimento). Devolve a fatia a partir dessa nova mensagem. Se o
+    encerramento é a última mensagem do cidadão (turno de despedida em si, sem
+    follow-up), devolve tudo — pra a despedida ser contextual. Sem encerramento,
+    devolve tudo.
+    """
+    msgs = list(messages)
+    close_idxs = [
+        i
+        for i, m in enumerate(msgs)
+        if is_human(m) and detect_close_intent(message_text(m))
+    ]
+    if not close_idxs:
+        return msgs
+    # Do encerramento mais recente pro mais antigo: o primeiro que tiver uma
+    # mensagem do cidadão depois dele marca o início do atendimento atual.
+    for close_idx in reversed(close_idxs):
+        for j in range(close_idx + 1, len(msgs)):
+            if is_human(msgs[j]):
+                return msgs[j:]
+    # Encerramento é o último turno do cidadão → ainda não resetou.
+    return msgs
+
+
+def apply_session_reset(state: Mapping[str, Any], final_state: dict) -> dict:
+    """Trunca o input do LLM pro atendimento atual quando houve um encerramento.
+
+    Lê o histórico **persistido** (``state['messages']``); se um encerramento já
+    foi seguido por nova mensagem, reconstrói ``llm_input_messages`` =
+    SystemMessages (memória de longo prazo / system, preservados) + as mensagens
+    de conversa do atendimento atual. Não mexe em ``messages`` (canal
+    persistido). No-op quando não há reset.
+    """
+    full = list(state.get("messages", []))
+    session = current_session_messages(full)
+    if len(session) >= len(full):
+        return final_state  # sem encerramento completo → nada a truncar
+
+    current = final_state.get("llm_input_messages")
+    if current is None:
+        current = final_state.get("messages") or full
+
+    system_msgs = [m for m in current if isinstance(m, SystemMessage)]
+    session_conv = [m for m in session if not isinstance(m, SystemMessage)]
+    return {**final_state, "llm_input_messages": [*system_msgs, *session_conv]}

--- a/engine/text_match.py
+++ b/engine/text_match.py
@@ -1,0 +1,45 @@
+"""Helpers de matching de texto PT-BR compartilhados pelos detectores
+determinísticos de intenção (``audio_mode``, ``session_boundary``).
+
+Pequenos, puros e sem estado — extraídos pra um só lugar pra os dois
+detectores normalizarem e lerem mensagens da mesma forma (acento-insensível,
+tolerante a content em str ou lista de blocos, e a mensagens humano/dict).
+"""
+
+import unicodedata
+from typing import Any, Mapping
+
+from langchain_core.messages import HumanMessage
+
+
+def normalize(text: str) -> str:
+    """Minúsculo + sem acentos, pra casar frases independente de grafia."""
+    decomposed = unicodedata.normalize("NFKD", text)
+    stripped = "".join(c for c in decomposed if not unicodedata.combining(c))
+    return stripped.lower()
+
+
+def message_text(message: Any) -> str:
+    """Extrai o texto de uma mensagem (content str ou lista de blocos)."""
+    content = getattr(message, "content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, Mapping) and isinstance(block.get("text"), str):
+                parts.append(block["text"])
+        return " ".join(parts)
+    return str(content) if content is not None else ""
+
+
+def is_human(message: Any) -> bool:
+    """True se a mensagem é do cidadão (HumanMessage ou role/type human/user)."""
+    if isinstance(message, HumanMessage):
+        return True
+    role = getattr(message, "type", None) or getattr(message, "role", None)
+    if role is None and isinstance(message, Mapping):
+        role = message.get("type") or message.get("role")
+    return role in ("human", "user")

--- a/src/prompt_modules/session_close.py
+++ b/src/prompt_modules/session_close.py
@@ -7,12 +7,19 @@ assunto (pivot tratado em ``workflow_continuation``). Faltava reconhecer a
 intenção explícita de finalizar ("tchau", "era só isso", "pode encerrar") e
 fechar com cordialidade — sem deixar um workflow em aberto no limbo.
 
-Não depende de tool nova: o fechamento é comportamento conversacional. O
-cancelamento de workflow ativo reusa o mesmo mecanismo de
-``workflow_continuation`` (chamar ``multi_step_service`` com sinal de
-cancelamento, ou parar de mantê-lo ativo). O logout gov.br, quando aplicável,
-é tratado pelo módulo ``govbr_auth_gating`` (logout a pedido do cidadão) — não
-duplicado aqui pra não instruir uma tool que pode não estar bound.
+A despedida é comportamento conversacional (este módulo). Mas o **reset de
+sessão** — pra a próxima mensagem começar limpa — NÃO é mais só conversacional:
+é mecânico, em ``engine/session_boundary.py``. Ele detecta o encerramento e, na
+mensagem seguinte, trunca o ``llm_input_messages`` pro atendimento atual
+(contexto + preferências como modo áudio resetam; memória de longo prazo
+persiste por design). Antes desse mecanismo, "encerrar" só dava tchau e a
+conversa seguinte continuava o mesmo thread — a preferência de áudio vazava
+(bug que motivou isto). O cancelamento de workflow ativo reusa o mesmo
+mecanismo de ``workflow_continuation`` (chamar ``multi_step_service`` com sinal
+de cancelamento, ou parar de mantê-lo ativo). O logout gov.br, quando
+aplicável, é tratado pelo módulo ``govbr_auth_gating`` (logout a pedido do
+cidadão) — não duplicado aqui pra não instruir uma tool que pode não estar
+bound.
 
 Sempre ativo (sem flag): como não chama tool, não há risco de instruir tool
 não-bound — mesmo critério dos módulos ``workflow_continuation`` /

--- a/tests/unit/test_session_boundary.py
+++ b/tests/unit/test_session_boundary.py
@@ -1,0 +1,187 @@
+"""Testes do boundary de sessão (engine/session_boundary.py)."""
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+from engine.audio_mode import derive_audio_mode
+from engine.session_boundary import (
+    apply_session_reset,
+    current_session_messages,
+    detect_close_intent,
+)
+
+
+def _h(text):
+    return HumanMessage(content=text)
+
+
+def _a(text="ok"):
+    return AIMessage(content=text)
+
+
+# --------------------------------------------------------------------------- #
+# detect_close_intent
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "text",
+    [
+        "tchau",
+        "obrigado, tchau!",
+        "era só isso",
+        "era só isso mesmo, valeu",
+        "pode encerrar",
+        "quero encerrar o atendimento",
+        "encerrar atendimento",
+        "finalizar o atendimento",
+        "valeu, até mais",
+        "até logo",
+        "não preciso de mais nada",
+        "não preciso de mais ajuda",
+    ],
+)
+def test_close_intent_detected(text):
+    assert detect_close_intent(text) is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "obrigado",  # gratidão pura não encerra
+        "valeu",
+        "qual o horário do posto?",
+        "quero abrir um chamado de luminária",
+        "me responde sempre em áudio",
+        "quero ler o edital",
+        "",
+        # "encerrar <serviço>" é PEDIDO, não fim de sessão (não pode truncar contexto)
+        "quero encerrar minha conta de luz",
+        "vou encerrar minha matrícula na escola",
+        "quero encerrar o contrato de aluguel",
+        "preciso encerrar meu MEI",
+        "como faço pra encerrar minha inscrição?",
+        "quero encerrar o parcelamento da dívida",
+        # gratidão com objeto pendente não encerra
+        "não preciso de mais nada além do boleto",
+    ],
+)
+def test_close_intent_not_detected(text):
+    assert detect_close_intent(text) is False
+
+
+def test_service_request_with_encerrar_does_not_truncate_context():
+    """'quero encerrar minha conta' no meio do atendimento NÃO reseta a sessão."""
+    msgs = [
+        _h("quero encerrar minha conta de luz"),
+        _a("Claro, me passa o número da instalação"),
+        _h("é a instalação 12345"),
+    ]
+    # nenhum encerramento detectado → contexto inteiro preservado
+    assert current_session_messages(msgs) == msgs
+
+
+# --------------------------------------------------------------------------- #
+# current_session_messages
+# --------------------------------------------------------------------------- #
+def test_no_close_returns_full():
+    msgs = [_h("oi"), _a("olá"), _h("qual o horário?")]
+    assert current_session_messages(msgs) == msgs
+
+
+def test_close_as_latest_turn_returns_full():
+    # despedida é a última mensagem do cidadão → ainda não resetou (goodbye contextual)
+    msgs = [_h("oi"), _a("olá"), _h("pode encerrar")]
+    assert current_session_messages(msgs) == msgs
+
+
+def test_reset_starts_at_first_human_after_close():
+    msgs = [
+        _h("oi"),
+        _a("olá"),
+        _h("pode encerrar"),  # close
+        _a("Prontinho! Até mais 👋"),  # goodbye
+        _h("na verdade, qual o horário do posto?"),  # nova sessão começa aqui
+        _a("é das 7h às 17h"),
+    ]
+    out = current_session_messages(msgs)
+    assert out == msgs[4:]
+    assert out[0].content.startswith("na verdade")
+
+
+def test_most_recent_completed_close_wins():
+    msgs = [
+        _h("tchau"),
+        _a("até mais"),
+        _h("oi de novo"),  # sessão 2
+        _a("olá"),
+        _h("era só isso"),  # close 2
+        _a("valeu!"),
+        _h("opa, mais uma coisa"),  # sessão 3 começa aqui
+    ]
+    out = current_session_messages(msgs)
+    assert out == msgs[6:]
+
+
+def test_empty():
+    assert current_session_messages([]) == []
+
+
+# --------------------------------------------------------------------------- #
+# apply_session_reset
+# --------------------------------------------------------------------------- #
+def test_apply_reset_noop_without_close():
+    state = {"messages": [_h("oi"), _a("olá"), _h("horário?")]}
+    final_state = {"llm_input_messages": list(state["messages"])}
+    out = apply_session_reset(state, final_state)
+    assert out is final_state
+
+
+def test_apply_reset_truncates_to_current_session_keeping_system():
+    full = [
+        _h("fica sempre em áudio"),
+        _a("ok, áudio"),
+        _h("pode encerrar"),
+        _a("até mais 👋"),
+        _h("qual o horário do posto?"),  # nova sessão
+    ]
+    state = {"messages": full}
+    mem = SystemMessage(content="[memória de longo prazo] cidadão chama-se Maria")
+    final_state = {"llm_input_messages": [mem, *full]}
+
+    out = apply_session_reset(state, final_state)
+    llm = out["llm_input_messages"]
+    # memória preservada
+    assert llm[0] is mem
+    # só a mensagem da sessão nova (sem o histórico pré-encerramento)
+    conv = [m for m in llm if not isinstance(m, SystemMessage)]
+    assert len(conv) == 1
+    assert conv[0].content == "qual o horário do posto?"
+    # messages (persistido) intocado
+    assert state["messages"] == full
+
+
+# --------------------------------------------------------------------------- #
+# Integração com audio_mode: áudio reseta após encerramento
+# --------------------------------------------------------------------------- #
+def test_audio_mode_resets_after_close():
+    # cidadão ligou áudio contínuo, encerrou, e mandou nova mensagem → áudio OFF
+    full = [
+        _h("responde sempre em áudio"),
+        _a("ok"),
+        _h("pode encerrar"),
+        _a("até mais"),
+        _h("qual o horário do posto?"),
+    ]
+    # derive sobre o histórico completo ainda veria o "sempre em áudio"
+    assert derive_audio_mode(full) is True
+    # mas sobre a sessão atual (pós-close) → OFF
+    assert derive_audio_mode(current_session_messages(full)) is False
+
+
+def test_audio_mode_persists_within_same_session():
+    # sem encerramento, áudio contínuo persiste
+    full = [
+        _h("responde sempre em áudio"),
+        _a("ok"),
+        _h("qual o horário do posto?"),
+    ]
+    assert derive_audio_mode(current_session_messages(full)) is True


### PR DESCRIPTION
## Bug

Ao encerrar o atendimento ("tchau"/"pode encerrar") e mandar uma **nova mensagem**, o bot continuava respondendo em áudio (e mantinha todo o contexto). Causa: o `session_close` é **puramente conversacional** (só dá tchau) e o `thread_id` é o telefone (fixo) — então a conversa seguinte continua o **mesmo thread** no checkpointer, e preferências/contexto vazam pro próximo atendimento. O áudio foi só o sintoma visível.

## Fix (Engine-only, comportamental — sem tocar Gateway, sem deletar Postgres)

- **`engine/session_boundary.py`** (novo): `detect_close_intent` (determinístico, **conservador** — exclui "encerrar minha conta/contrato/matrícula/MEI…" que são pedidos de serviço reais, via negative-lookahead) + `current_session_messages` (devolve só as mensagens do atendimento ATUAL, após o último encerramento já respondido) + `apply_session_reset` (trunca `llm_input_messages` — canal **não-persistente** — pra essa fatia, preservando SystemMessages de memória).
- **`engine/agent.py`**: `pre_model_hook` chama `apply_session_reset` antes do `inject_audio_directive`. Após "tchau" + nova msg → contexto começa limpo e modo áudio reseta.
- **`engine/audio_mode.py`**: deriva a preferência de `current_session_messages` (reseta após encerramento), não do histórico inteiro.
- **`engine/text_match.py`** (novo): helpers PT-BR (`normalize`/`message_text`/`is_human`) compartilhados — extraídos dos privados duplicados no `audio_mode`.
- **`session_close.py`**: docstring atualizada (sem mudança no `MODULE_PROMPT` — não infla tokens; o reset é mecânico).

Memória de longo prazo **persiste por design** (injetada à parte como SystemMessage) — o bot esquece a conversa anterior mas continua lembrando quem você é.

## O que NÃO faz (follow-up)

Reset "duro" = rotacionar `thread_id` no Gateway + limpar checkpoints Postgres. Resolveria também o **crescimento de storage** do thread (que cresce pra sempre hoje, independente deste PR). É cross-repo (Go) + governança — fica como follow-up.

## Testes

`tests/unit/test_session_boundary.py` (novo): detecção de close ON/OFF, **classe de falso-positivo "encerrar <serviço>"** (não trunca contexto), `current_session_messages` (sem close → full; close como último turno → full; reset a partir da 1ª msg pós-close; múltiplos closes → mais recente), `apply_session_reset` (no-op / trunca preservando memória), e integração com `audio_mode` (áudio reseta após close, persiste na mesma sessão). **74 testes** verdes + `test_audio_mode`/`test_prompt_modules` seguem verdes (117 no total).

## Revisão

Code-reviewer (Opus): aprovado. Um blocker (padrão `encerrar` pegava pedidos de serviço) foi corrigido com negative-lookahead + testes da classe; residual benigno ("encerrar uma conta") também coberto.

Refs: #85 (audio-mode), #87 (trim), #237 (session_close original).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
