### PR TITLE
fix(engine): resiliência a erro de tool — rede de segurança + monitoramento real

### DIFF
--- a/engine/agent.py
+++ b/engine/agent.py
@@ -3,6 +3,7 @@ import asyncio
 import hashlib
 import json
 import random
+import traceback as _traceback
 from datetime import datetime, timezone
 from functools import wraps
 from os import getenv
@@ -47,6 +48,7 @@ from engine.utils import (
     interceptor,
     extract_thread_id_from_config,
     make_source,
+    send_general_error,
     PRE_INVOKE,
     PRE_INVOKE_SANITIZE,
     PRE_INVOKE_COMBINED,
@@ -66,6 +68,55 @@ from engine.utils import (
     RESPONSE_FILTER,
     RESPONSE_FILTER_FILTER,
 )
+
+
+# Resposta de fallback quando a execução do grafo falha de forma não-recuperável
+# (erro de protocolo MCP, recursion limit, etc.). Em vez de propagar a exceção
+# — que vira o erro genérico do Gateway — o engine devolve esta mensagem,
+# guiando o cidadão (inclusive pro caminho de endereço por texto, relevante ao
+# bug do pin de localização no fluxo de luminária).
+ENGINE_FALLBACK_MESSAGE = (
+    "Desculpe, tive um problema técnico ao processar sua mensagem agora. "
+    "Pode tentar enviar de novo? Se você mandou uma localização, tente digitar "
+    "o endereço (rua/avenida, número se souber, e bairro)."
+)
+
+
+async def _report_graph_failure(source: dict, exc: Exception, kwargs: dict) -> None:
+    """Reporta falha de grafo ao error interceptor.
+
+    A rede de segurança do Agent.query devolve um fallback em vez de propagar a
+    exceção — mas isso faz o `@interceptor` (que só reporta em exceção propagada)
+    perder o erro. Este helper preserva esse canal de monitoramento, reportando
+    explicitamente antes do fallback.
+    """
+    try:
+        thread_id = (
+            (kwargs.get("config", {}) or {})
+            .get("configurable", {})
+            .get("thread_id", "unknown")
+        )
+        await send_general_error(
+            user_id=thread_id,
+            source=dict(source),
+            error_type=type(exc).__name__,
+            error_message=str(exc)[:300],
+            traceback=_traceback.format_exc(),
+        )
+    except Exception as report_error:  # nunca deixar o report quebrar o fallback
+        logger.warning(f"[Engine] Falha ao reportar erro de grafo: {report_error}")
+
+
+def _report_graph_failure_sync(source: dict, exc: Exception, kwargs: dict) -> None:
+    """Variante sync-safe: usa o loop corrente se houver, senão roda um efêmero."""
+    try:
+        loop = asyncio.get_running_loop()
+        loop.create_task(_report_graph_failure(source, exc, kwargs))
+    except RuntimeError:
+        try:
+            asyncio.run(_report_graph_failure(source, exc, kwargs))
+        except Exception as report_error:
+            logger.warning(f"[Engine] Falha ao reportar erro de grafo (sync): {report_error}")
 
 
 class IntVersionPostgresSaver(AsyncPostgresSaver):
@@ -1373,13 +1424,23 @@ class Agent(AsyncQueryable, AsyncStreamQueryable, Queryable, StreamQueryable):
                 }
             except Exception as e:
                 return {"status_code": 500, "status": "error", "message": str(e)}
-        result = await self._graph.ainvoke(**kwargs)
-        filtered_result = self._filter_current_interaction(result)
+        try:
+            result = await self._graph.ainvoke(**kwargs)
+            filtered_result = self._filter_current_interaction(result)
 
-        # Simple tracing
-        self._trace_conversation(filtered_result, **kwargs)
+            # Simple tracing
+            self._trace_conversation(filtered_result, **kwargs)
 
-        return filtered_result
+            return filtered_result
+        except Exception as e:
+            logger.error(
+                f"[async_query] Falha na execução do grafo; devolvendo fallback: {e}",
+                exc_info=True,
+            )
+            await _report_graph_failure(
+                make_source(GRAPH_INVOCATION, GRAPH_ASYNC_QUERY), e, kwargs
+            )
+            return {"messages": [AIMessage(content=ENGINE_FALLBACK_MESSAGE)]}
 
     @interceptor(
         source=make_source(GRAPH_INVOCATION, GRAPH_ASYNC_STREAM),
@@ -1395,9 +1456,20 @@ class Agent(AsyncQueryable, AsyncStreamQueryable, Queryable, StreamQueryable):
                 raise ValueError(
                     "Graph is not initialized. Call _ensure_async_setup first."
                 )
-            async for chunk in self._graph.astream(**kwargs):
-                filtered_chunk = self._filter_streaming_chunk(chunk)
-                yield dumpd(filtered_chunk)
+            try:
+                async for chunk in self._graph.astream(**kwargs):
+                    filtered_chunk = self._filter_streaming_chunk(chunk)
+                    yield dumpd(filtered_chunk)
+            except Exception as e:
+                logger.error(
+                    f"[async_stream_query] Falha no streaming do grafo; "
+                    f"devolvendo fallback: {e}",
+                    exc_info=True,
+                )
+                await _report_graph_failure(
+                    make_source(GRAPH_INVOCATION, GRAPH_ASYNC_STREAM), e, kwargs
+                )
+                yield dumpd({"messages": [AIMessage(content=ENGINE_FALLBACK_MESSAGE)]})
 
         return async_generator()
 
@@ -1412,13 +1484,26 @@ class Agent(AsyncQueryable, AsyncStreamQueryable, Queryable, StreamQueryable):
         if self._graph is None:
             raise ValueError("Graph is not initialized. Call _ensure_sync_setup first.")
 
-        result = self._graph.invoke(**kwargs)
-        filtered_result = self._filter_current_interaction(result)
+        try:
+            result = self._graph.invoke(**kwargs)
+            filtered_result = self._filter_current_interaction(result)
 
-        # Simple tracing
-        self._trace_conversation(filtered_result, **kwargs)
+            # Simple tracing
+            self._trace_conversation(filtered_result, **kwargs)
 
-        return filtered_result
+            return filtered_result
+        except Exception as e:
+            # Rede de segurança: uma falha na execução do grafo (ex.: erro de
+            # protocolo MCP, recursion limit, falha de tool não-recuperável) NÃO
+            # deve propagar como erro cru — devolve um fallback amigável.
+            logger.error(
+                f"[query] Falha na execução do grafo; devolvendo fallback: {e}",
+                exc_info=True,
+            )
+            _report_graph_failure_sync(
+                make_source(GRAPH_INVOCATION, GRAPH_QUERY), e, kwargs
+            )
+            return {"messages": [AIMessage(content=ENGINE_FALLBACK_MESSAGE)]}
 
     @interceptor(
         source=make_source(GRAPH_INVOCATION, GRAPH_STREAM),
@@ -1430,9 +1515,19 @@ class Agent(AsyncQueryable, AsyncStreamQueryable, Queryable, StreamQueryable):
         self._ensure_sync_setup()
         if self._graph is None:
             raise ValueError("Graph is not initialized. Call _ensure_sync_setup first.")
-        for chunk in self._graph.stream(**kwargs):
-            filtered_chunk = self._filter_streaming_chunk(chunk)
-            yield dumpd(filtered_chunk)
+        try:
+            for chunk in self._graph.stream(**kwargs):
+                filtered_chunk = self._filter_streaming_chunk(chunk)
+                yield dumpd(filtered_chunk)
+        except Exception as e:
+            logger.error(
+                f"[stream_query] Falha no streaming do grafo; devolvendo fallback: {e}",
+                exc_info=True,
+            )
+            _report_graph_failure_sync(
+                make_source(GRAPH_INVOCATION, GRAPH_STREAM), e, kwargs
+            )
+            yield dumpd({"messages": [AIMessage(content=ENGINE_FALLBACK_MESSAGE)]})
 
     @interceptor(
         source=make_source(RESPONSE_FILTER, RESPONSE_FILTER_FILTER),

--- a/engine/agent.py
+++ b/engine/agent.py
@@ -107,12 +107,23 @@ async def _report_graph_failure(source: dict, exc: Exception, kwargs: dict) -> N
         logger.warning(f"[Engine] Falha ao reportar erro de grafo: {report_error}")
 
 
+# Retém referência forte dos reports fire-and-forget. Sem isso, o asyncio só
+# guarda uma weakref do task criado por create_task — se o caller retorna antes
+# do report completar, o task pode ser coletado e o erro nunca chega ao monitor.
+_PENDING_GRAPH_REPORT_TASKS: set = set()
+
+
 def _report_graph_failure_sync(source: dict, exc: Exception, kwargs: dict) -> None:
     """Variante sync-safe: usa o loop corrente se houver, senão roda um efêmero."""
     try:
         loop = asyncio.get_running_loop()
-        loop.create_task(_report_graph_failure(source, exc, kwargs))
     except RuntimeError:
+        loop = None
+    if loop is not None:
+        task = loop.create_task(_report_graph_failure(source, exc, kwargs))
+        _PENDING_GRAPH_REPORT_TASKS.add(task)
+        task.add_done_callback(_PENDING_GRAPH_REPORT_TASKS.discard)
+    else:
         try:
             asyncio.run(_report_graph_failure(source, exc, kwargs))
         except Exception as report_error:

--- a/engine/agent.py
+++ b/engine/agent.py
@@ -1444,9 +1444,8 @@ class Agent(AsyncQueryable, AsyncStreamQueryable, Queryable, StreamQueryable):
 
             return filtered_result
         except Exception as e:
-            logger.error(
-                f"[async_query] Falha na execução do grafo; devolvendo fallback: {e}",
-                exc_info=True,
+            logger.opt(exception=True).error(
+                "[async_query] Falha na execução do grafo; devolvendo fallback: {}", e
             )
             await _report_graph_failure(
                 make_source(GRAPH_INVOCATION, GRAPH_ASYNC_QUERY), e, kwargs
@@ -1472,10 +1471,10 @@ class Agent(AsyncQueryable, AsyncStreamQueryable, Queryable, StreamQueryable):
                     filtered_chunk = self._filter_streaming_chunk(chunk)
                     yield dumpd(filtered_chunk)
             except Exception as e:
-                logger.error(
-                    f"[async_stream_query] Falha no streaming do grafo; "
-                    f"devolvendo fallback: {e}",
-                    exc_info=True,
+                logger.opt(exception=True).error(
+                    "[async_stream_query] Falha no streaming do grafo; "
+                    "devolvendo fallback: {}",
+                    e,
                 )
                 await _report_graph_failure(
                     make_source(GRAPH_INVOCATION, GRAPH_ASYNC_STREAM), e, kwargs
@@ -1507,9 +1506,8 @@ class Agent(AsyncQueryable, AsyncStreamQueryable, Queryable, StreamQueryable):
             # Rede de segurança: uma falha na execução do grafo (ex.: erro de
             # protocolo MCP, recursion limit, falha de tool não-recuperável) NÃO
             # deve propagar como erro cru — devolve um fallback amigável.
-            logger.error(
-                f"[query] Falha na execução do grafo; devolvendo fallback: {e}",
-                exc_info=True,
+            logger.opt(exception=True).error(
+                "[query] Falha na execução do grafo; devolvendo fallback: {}", e
             )
             _report_graph_failure_sync(
                 make_source(GRAPH_INVOCATION, GRAPH_QUERY), e, kwargs
@@ -1531,9 +1529,8 @@ class Agent(AsyncQueryable, AsyncStreamQueryable, Queryable, StreamQueryable):
                 filtered_chunk = self._filter_streaming_chunk(chunk)
                 yield dumpd(filtered_chunk)
         except Exception as e:
-            logger.error(
-                f"[stream_query] Falha no streaming do grafo; devolvendo fallback: {e}",
-                exc_info=True,
+            logger.opt(exception=True).error(
+                "[stream_query] Falha no streaming do grafo; devolvendo fallback: {}", e
             )
             _report_graph_failure_sync(
                 make_source(GRAPH_INVOCATION, GRAPH_STREAM), e, kwargs

--- a/engine/monitored_tool_node.py
+++ b/engine/monitored_tool_node.py
@@ -1,183 +1,182 @@
 """
 Monitored Tool Node
 
-A wrapper around LangGraph's ToolNode that adds automatic error reporting
-for tool execution failures. This provides visibility into which tools are
-failing and why, helping with debugging and monitoring.
+Wrapper do ToolNode do LangGraph que reporta erros de execução de tool ao
+interceptor de erros, dando visibilidade de quais tools falham e por quê.
+
+IMPORTANTE (langgraph 1.x): os entry-points do ToolNode são `_func`/`_afunc`
+(NÃO `_run`/`_arun`). A versão anterior sobrescrevia `_run`/`_arun`, que o base
+nunca chama — ou seja, o monitoramento estava silenciosamente morto.
+
+Esta versão sobrescreve os métodos corretos cobrindo os DOIS caminhos pelos
+quais um erro de tool aparece nesta versão do langgraph:
+
+1. **Exceção propagada** — com o `handle_tool_errors` default, uma exceção
+   levantada no corpo da tool (ex.: Google Maps fora do ar em
+   `reverse_geocode_address`) é RE-LEVANTADA pelo base, não convertida. O
+   override captura, reporta e re-levanta (a rede de segurança do Agent.query
+   converte em fallback amigável pro cidadão). Esse é o caso comum.
+2. **ToolMessage(status="error")** — quando o erro É convertido (ex.:
+   ToolInvocationError, ou handle_tool_errors configurado como bool/str), ele
+   chega como ToolMessage no resultado. O override inspeciona e reporta.
+
+O override é PASSTHROUGH: não altera o error handling do base — só dá
+observabilidade. A recuperação de UX fica com `Agent.query` (rede de segurança).
 """
 
-import traceback
-from typing import Any, Dict, List, Union
-from langchain_core.tools import BaseTool
-from langgraph.prebuilt.tool_node import ToolNode
-from langgraph.types import interrupt
+import asyncio
+from typing import Any, List, Tuple
 
-from engine.utils import send_general_error, make_tool_source, TOOL_EXECUTION
+from langchain_core.messages import ToolMessage
+from langchain_core.runnables import RunnableConfig
+from langgraph.prebuilt.tool_node import ToolNode
+from langgraph.runtime import Runtime
+
+from engine.utils import send_general_error, make_tool_source
 from engine.log import logger
 
 
 class MonitoredToolNode(ToolNode):
-    """
-    Enhanced ToolNode that reports tool execution errors to the error interceptor.
-    
-    Wraps LangGraph's ToolNode to add automatic error monitoring without changing
-    the tool execution behavior. Errors are reported asynchronously and do not
-    block or interfere with normal error propagation.
-    
-    Usage:
-        Instead of:
-            tool_node = ToolNode(tools)
-        
-        Use:
-            tool_node = MonitoredToolNode(tools)
+    """ToolNode que reporta erros de execução de tool sem alterar o comportamento.
+
+    As assinaturas de `_func`/`_afunc` espelham EXATAMENTE as do base, incluindo
+    anotações (`config: RunnableConfig`, `runtime: Runtime`). O langgraph inspeciona
+    essas anotações para injetar config/runtime; com `Any`, ele trata `runtime`
+    como config key e levanta "Missing required config key" — quebraria em produção.
     """
 
-    async def _arun(
-        self,
-        tool_input: Dict[str, Any],
-        *,
-        store: Any = None,
-        config: Dict[str, Any],
-        **kwargs: Any,
+    async def _afunc(
+        self, input: Any, config: RunnableConfig, runtime: Runtime
     ) -> Any:
-        """
-        Execute tool with error monitoring.
-        
-        This overrides ToolNode's _arun to wrap it with error reporting.
-        All errors are reported to the error interceptor before being re-raised.
-        """
-        tool_name = "unknown"
-        thread_id = "unknown"
-        
         try:
-            # Extract context for error reporting
-            tool_name = tool_input.get("name", "unknown") if isinstance(tool_input, dict) else "unknown"
-            
-            # Extract thread_id from config
-            if isinstance(config, dict):
-                configurable = config.get("configurable", {})
-                thread_id = configurable.get("thread_id", "unknown")
-            
-            # Execute the tool using parent class method
-            return await super()._arun(tool_input, store=store, config=config, **kwargs)
-            
-        except Exception as e:
-            # Report error to interceptor
-            try:
-                # Extract tool arguments for context
-                tool_args = {}
-                if isinstance(tool_input, dict):
-                    tool_args = tool_input.get("args", {})
-                    # Limit size of args to avoid huge payloads
-                    if isinstance(tool_args, dict):
-                        tool_args = {k: str(v)[:100] for k, v in list(tool_args.items())[:10]}
-                
-                # Create source with tool context
-                source = make_tool_source(
-                    tool_name=tool_name,
-                    context={"args_preview": tool_args} if tool_args else None
-                )
-                
-                # Send error report (non-blocking)
-                await send_general_error(
-                    user_id=thread_id,
-                    source=source,
-                    error_type=type(e).__name__,
-                    error_message=str(e),
-                    traceback=traceback.format_exc(),
-                    input_body=tool_input,
-                )
-                
-                logger.info(
-                    f"[Error Monitor] Reported tool execution error: {tool_name} | "
-                    f"Error: {type(e).__name__}: {str(e)[:100]}"
-                )
-                
-            except Exception as report_error:
-                # If error reporting fails, log but don't interfere with original error
-                logger.warning(
-                    f"[Error Monitor] Failed to report tool error: {report_error}"
-                )
-            
-            # Re-raise original error to maintain normal error flow
+            result = await super()._afunc(input, config, runtime)
+        except Exception as exc:
+            await self._report(self._pending_tool_names(input), repr(exc), config)
             raise
+        for tool_name, content in self._extract_tool_errors(result):
+            await self._report(tool_name, content, config)
+        return result
 
-    def _run(
-        self,
-        tool_input: Dict[str, Any],
-        *,
-        store: Any = None,
-        config: Dict[str, Any],
-        **kwargs: Any,
-    ) -> Any:
-        """
-        Synchronous tool execution with error monitoring.
-        
-        Similar to _arun but for synchronous execution.
-        Note: Error reporting is still async, handled via event loop.
-        """
-        tool_name = "unknown"
-        thread_id = "unknown"
-        
+    def _func(self, input: Any, config: RunnableConfig, runtime: Runtime) -> Any:
         try:
-            # Extract context for error reporting
-            tool_name = tool_input.get("name", "unknown") if isinstance(tool_input, dict) else "unknown"
-            
-            # Extract thread_id from config
-            if isinstance(config, dict):
-                configurable = config.get("configurable", {})
-                thread_id = configurable.get("thread_id", "unknown")
-            
-            # Execute the tool using parent class method
-            return super()._run(tool_input, store=store, config=config, **kwargs)
-            
-        except Exception as e:
-            # Report error to interceptor
-            try:
-                import asyncio
-                
-                # Extract tool arguments for context
-                tool_args = {}
-                if isinstance(tool_input, dict):
-                    tool_args = tool_input.get("args", {})
-                    # Limit size of args to avoid huge payloads
-                    if isinstance(tool_args, dict):
-                        tool_args = {k: str(v)[:100] for k, v in list(tool_args.items())[:10]}
-                
-                # Create source with tool context
-                source = make_tool_source(
-                    tool_name=tool_name,
-                    context={"args_preview": tool_args} if tool_args else None
-                )
-                
-                # Send error report (try to run async in current event loop)
-                try:
-                    loop = asyncio.get_running_loop()
-                    # Schedule error reporting as a task (fire and forget)
-                    loop.create_task(send_general_error(
-                        user_id=thread_id,
-                        source=source,
-                        error_type=type(e).__name__,
-                        error_message=str(e),
-                        traceback=traceback.format_exc(),
-                        input_body=tool_input,
-                    ))
-                except RuntimeError:
-                    # No event loop, skip async error reporting
-                    logger.warning(
-                        f"[Error Monitor] Cannot report sync tool error (no event loop): {tool_name}"
+            result = super()._func(input, config, runtime)
+        except Exception as exc:
+            self._report_sync(
+                [(self._pending_tool_names(input), repr(exc))], config
+            )
+            raise
+        errors = self._extract_tool_errors(result)
+        if errors:
+            self._report_sync(errors, config)
+        return result
+
+    # ------------------------------------------------------------------ helpers
+
+    def _pending_tool_names(self, input: Any) -> str:
+        """Nomes dos tool_calls que o ToolNode ia executar, extraídos do input.
+
+        Quando a tool levanta no corpo, o base re-levanta antes de qualquer
+        ToolMessage existir — então o nome da tool tem que vir do input. O ToolNode
+        recebe o input em dois formatos:
+
+        - **v2 (default do react agent)**: o routing faz `Send("tools", [tool_call])`,
+          então `input` é uma LISTA de dicts de tool_call diretos (`{"name", "args",
+          "id"}`). Esse é o path de produção.
+        - **v1 / state**: `input` é o state (`{"messages": [...]}`) ou uma lista de
+          mensagens; o nome vem dos `tool_calls` da última AIMessage.
+
+        Com 1 call é exato; com vários, junta os nomes para o alerta apontar o
+        conjunto que falhou.
+        """
+        try:
+            if isinstance(input, dict):
+                messages = input.get(self._messages_key, []) or []
+            elif isinstance(input, list):
+                # v2: itens são dicts de tool_call diretos (têm "name", não .tool_calls)
+                direct = [
+                    str(item["name"])
+                    for item in input
+                    if isinstance(item, dict) and item.get("name")
+                ]
+                if direct:
+                    return ",".join(direct)
+                messages = input
+            else:
+                return "unknown"
+            for msg in reversed(messages):
+                tool_calls = getattr(msg, "tool_calls", None)
+                if tool_calls:
+                    names = [str(tc["name"]) for tc in tool_calls if tc.get("name")]
+                    if names:
+                        return ",".join(names)
+            return "unknown"
+        except Exception:
+            return "unknown"
+
+    def _extract_tool_errors(self, result: Any) -> List[Tuple[str, str]]:
+        """Extrai (tool_name, content) das ToolMessages com status='error'."""
+        try:
+            if isinstance(result, dict):
+                messages = result.get(self._messages_key, []) or []
+            elif isinstance(result, list):
+                messages = result
+            else:
+                return []
+            errors: List[Tuple[str, str]] = []
+            for msg in messages:
+                if (
+                    isinstance(msg, ToolMessage)
+                    and getattr(msg, "status", None) == "error"
+                ):
+                    errors.append(
+                        (
+                            getattr(msg, "name", None) or "unknown",
+                            str(getattr(msg, "content", "")),
+                        )
                     )
-                
-                logger.info(
-                    f"[Error Monitor] Reported tool execution error: {tool_name} | "
-                    f"Error: {type(e).__name__}: {str(e)[:100]}"
-                )
-                
-            except Exception as report_error:
-                # If error reporting fails, log but don't interfere with original error
-                logger.warning(
-                    f"[Error Monitor] Failed to report tool error: {report_error}"
-                )
-            
-            # Re-raise original error to maintain normal error flow
-            raise
+            return errors
+        except Exception:
+            return []
+
+    async def _report(self, tool_name: str, content: str, config: Any) -> None:
+        try:
+            thread_id = "unknown"
+            if isinstance(config, dict):
+                thread_id = config.get("configurable", {}).get("thread_id", "unknown")
+            await send_general_error(
+                user_id=thread_id,
+                source=make_tool_source(tool_name=tool_name),
+                error_type="ToolExecutionError",
+                error_message=content[:500],
+                traceback=None,
+            )
+            logger.info(
+                f"[Error Monitor] Tool error reportado: {tool_name} | {content[:100]}"
+            )
+        except Exception as report_error:
+            logger.warning(
+                f"[Error Monitor] Falha ao reportar erro de tool: {report_error}"
+            )
+
+    def _report_sync(self, errors: List[Tuple[str, str]], config: Any) -> None:
+        """Reporta erros de tool a partir do caminho síncrono.
+
+        Se há loop corrente, agenda (fire-and-forget). Senão (caso comum no path
+        sync `graph.invoke`/`Agent.query`, ou em thread de executor), roda um loop
+        efêmero via `asyncio.run` — sem isso o erro sync nunca chegaria ao monitor.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        for tool_name, content in errors:
+            if loop is not None:
+                loop.create_task(self._report(tool_name, content, config))
+            else:
+                try:
+                    asyncio.run(self._report(tool_name, content, config))
+                except Exception as report_error:
+                    logger.warning(
+                        f"[Error Monitor] Falha ao reportar erro de tool (sync): "
+                        f"{report_error}"
+                    )

--- a/engine/monitored_tool_node.py
+++ b/engine/monitored_tool_node.py
@@ -35,6 +35,11 @@ from langgraph.runtime import Runtime
 from engine.utils import send_general_error, make_tool_source
 from engine.log import logger
 
+# Retém referência forte dos reports fire-and-forget. asyncio só mantém weakref
+# do task de create_task — sem isso, se o caller retorna antes do report
+# completar, o task pode ser coletado e o erro de tool nunca chega ao monitor.
+_PENDING_REPORT_TASKS: set = set()
+
 
 class MonitoredToolNode(ToolNode):
     """ToolNode que reporta erros de execução de tool sem alterar o comportamento.
@@ -171,7 +176,9 @@ class MonitoredToolNode(ToolNode):
             loop = None
         for tool_name, content in errors:
             if loop is not None:
-                loop.create_task(self._report(tool_name, content, config))
+                task = loop.create_task(self._report(tool_name, content, config))
+                _PENDING_REPORT_TASKS.add(task)
+                task.add_done_callback(_PENDING_REPORT_TASKS.discard)
             else:
                 try:
                     asyncio.run(self._report(tool_name, content, config))

--- a/tests/unit/test_engine_resilience.py
+++ b/tests/unit/test_engine_resilience.py
@@ -1,0 +1,156 @@
+"""Testes da resiliência do engine a erro de tool (fix do bug do pin de
+localização / luminária):
+
+- A: query()/async_query() devolvem fallback amigável em vez de propagar a
+  exceção (que viraria o erro genérico do Gateway) E ainda reportam ao
+  interceptor (monitoramento não some por causa do catch).
+- B: MonitoredToolNode reporta erros de tool sobrescrevendo _func/_afunc (os
+  métodos reais do langgraph 1.x; a versão antiga sobrescrevia _run/_arun, que
+  o base nunca chama — monitoramento morto). Nesta versão do langgraph o
+  handle_tool_errors default RE-LEVANTA exceções do corpo da tool (só converte
+  ToolInvocationError), então o override reporta no caminho de propagação e
+  re-levanta — deixando a UX pra rede de segurança do Agent.query.
+"""
+
+import asyncio
+
+import pytest
+from unittest.mock import patch
+
+from langchain_core.messages import AIMessage
+from langchain_core.tools import tool
+from langgraph.graph import StateGraph, START, END, MessagesState
+
+import engine.monitored_tool_node as mtn
+from engine.monitored_tool_node import MonitoredToolNode
+
+
+@tool
+def failing_tool(x: str) -> str:
+    """Tool que sempre falha (para testar resiliência)."""
+    raise RuntimeError("simulated tool failure")
+
+
+def _build_graph_with_node(node):
+    """Mini-grafo: nó semente injeta um tool_call, depois roda o ToolNode.
+
+    Roda dentro de um StateGraph compilado (não standalone) porque é só aí que o
+    langgraph popula o Runtime que `_afunc`/`_func` exigem — fiel à produção.
+    """
+
+    def seed(state):
+        return {
+            "messages": [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {"name": "failing_tool", "args": {"x": "y"}, "id": "call_1"}
+                    ],
+                )
+            ]
+        }
+
+    g = StateGraph(MessagesState)
+    g.add_node("seed", seed)
+    g.add_node("tools", node)
+    g.add_edge(START, "seed")
+    g.add_edge("seed", "tools")
+    g.add_edge("tools", END)
+    return g.compile()
+
+
+def test_monitored_tool_node_reports_propagating_tool_error():
+    """B: exceção no corpo da tool propaga (default handle_tool_errors) E é reportada.
+
+    Esse é o caso comum em produção: nesta versão do langgraph a exceção é
+    re-levantada pelo base. O override precisa reportá-la (monitoramento) e
+    re-levantar (a rede de segurança do Agent.query trata a UX).
+    """
+    app = _build_graph_with_node(MonitoredToolNode([failing_tool]))
+
+    async def run():
+        # patch() auto-usa AsyncMock porque send_general_error é coroutine.
+        with patch.object(mtn, "send_general_error") as mock_report:
+            with pytest.raises(Exception):  # a exceção da tool propaga
+                await app.ainvoke(
+                    {"messages": []},
+                    config={"configurable": {"thread_id": "5521999999999"}},
+                )
+            return mock_report
+
+    mock_report = asyncio.run(run())
+
+    # monitoramento disparou (override _afunc é o método real, não código morto)
+    assert mock_report.await_count >= 1 or mock_report.call_count >= 1
+    # e o report identifica a tool que falhou + carrega a mensagem do erro
+    reported = str(mock_report.call_args)
+    assert "simulated tool failure" in reported
+    assert "failing_tool" in reported  # nome extraído do input, não "unknown"
+
+
+def test_pending_tool_names_handles_v2_and_state_inputs():
+    """B': nome da tool é extraído nos dois formatos de input do ToolNode.
+
+    v2 (produção) entrega `[tool_call_dict]` via Send; v1/state entrega
+    `{"messages": [...]}`. Ambos devem render o nome real, nunca "unknown".
+    """
+    node = MonitoredToolNode([failing_tool])
+
+    # v2: lista de tool-call dicts diretos (path de produção via Send)
+    v2_input = [{"name": "reverse_geocode_address", "args": {}, "id": "c1"}]
+    assert node._pending_tool_names(v2_input) == "reverse_geocode_address"
+
+    # state dict com AIMessage
+    state_input = {
+        "messages": [
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "create_ticket", "args": {}, "id": "c2"}],
+            )
+        ]
+    }
+    assert node._pending_tool_names(state_input) == "create_ticket"
+
+    # input opaco → degrada para "unknown" sem levantar
+    assert node._pending_tool_names(object()) == "unknown"
+
+
+def test_query_returns_fallback_on_graph_error():
+    """A: query() devolve a mensagem de fallback quando o grafo levanta.
+
+    query() está em Agent (decorada com @interceptor, que repassa em caso de
+    sucesso). Em vez de construir o Agent inteiro (pesado: Vertex/checkpointer),
+    invocamos Agent.query bound a um fake self com só os atributos que o caminho
+    de erro toca.
+    """
+    from types import SimpleNamespace
+
+    from engine.agent import Agent, ENGINE_FALLBACK_MESSAGE
+
+    class _BoomGraph:
+        def invoke(self, **kwargs):
+            raise RuntimeError("graph boom")
+
+    fake_self = SimpleNamespace(
+        _graph=_BoomGraph(),
+        _combined_pre_invoke_hook=lambda **kw: kw,
+        _ensure_sync_setup=lambda: None,
+        _filter_current_interaction=lambda r: r,
+        _trace_conversation=lambda r, **kw: None,
+    )
+
+    import engine.agent as agent_mod
+
+    with patch.object(agent_mod, "send_general_error") as mock_report:
+        result = Agent.query(
+            fake_self,
+            input={"messages": []},
+            config={"configurable": {"thread_id": "test"}},
+        )
+
+    messages = result["messages"]
+    assert isinstance(messages[0], AIMessage)
+    assert messages[0].content == ENGINE_FALLBACK_MESSAGE
+    # a rede de segurança devolve fallback MAS preserva o monitoramento:
+    # o erro de grafo é reportado ao interceptor (não some).
+    assert mock_report.await_count >= 1 or mock_report.call_count >= 1

--- a/tests/unit/test_engine_resilience.py
+++ b/tests/unit/test_engine_resilience.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 from langchain_core.messages import AIMessage
 from langchain_core.tools import tool
 from langgraph.graph import StateGraph, START, END, MessagesState
+from langgraph.types import Send
 
 import engine.monitored_tool_node as mtn
 from engine.monitored_tool_node import MonitoredToolNode
@@ -59,6 +60,40 @@ def _build_graph_with_node(node):
     return g.compile()
 
 
+def _build_graph_with_send_dispatch(node):
+    """Mini-grafo que despacha pro ToolNode via `Send("tools", [tool_call])`.
+
+    Replica EXATAMENTE o routing v2 do engine (custom_react_agent.py:906/988):
+    o nó "tools" recebe `[tool_call_dict]` (lista), não o state — o path real de
+    produção. Garante que `_pending_tool_names` extraia o nome por dentro do
+    `_afunc`/grafo, não só no helper isolado.
+    """
+
+    def seed(state):
+        return {
+            "messages": [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {"name": "failing_tool", "args": {"x": "y"}, "id": "call_1"}
+                    ],
+                )
+            ]
+        }
+
+    def route(state):
+        last = state["messages"][-1]
+        return [Send("tools", [tc]) for tc in last.tool_calls]
+
+    g = StateGraph(MessagesState)
+    g.add_node("seed", seed)
+    g.add_node("tools", node)
+    g.add_edge(START, "seed")
+    g.add_conditional_edges("seed", route, ["tools"])
+    g.add_edge("tools", END)
+    return g.compile()
+
+
 def test_monitored_tool_node_reports_propagating_tool_error():
     """B: exceção no corpo da tool propaga (default handle_tool_errors) E é reportada.
 
@@ -86,6 +121,29 @@ def test_monitored_tool_node_reports_propagating_tool_error():
     reported = str(mock_report.call_args)
     assert "simulated tool failure" in reported
     assert "failing_tool" in reported  # nome extraído do input, não "unknown"
+
+
+def test_monitored_tool_node_reports_via_send_dispatch_v2():
+    """B (path de produção): com Send("tools", [tool_call]) o nó recebe a LISTA
+    de tool_call dicts — o input v2 real. O erro deve propagar E ser reportado
+    com o nome da tool extraído por dentro do _afunc (não "unknown")."""
+    app = _build_graph_with_send_dispatch(MonitoredToolNode([failing_tool]))
+
+    async def run():
+        with patch.object(mtn, "send_general_error") as mock_report:
+            with pytest.raises(Exception):
+                await app.ainvoke(
+                    {"messages": []},
+                    config={"configurable": {"thread_id": "5521999999999"}},
+                )
+            return mock_report
+
+    mock_report = asyncio.run(run())
+
+    assert mock_report.await_count >= 1 or mock_report.call_count >= 1
+    reported = str(mock_report.call_args)
+    assert "failing_tool" in reported  # nome extraído do [tool_call] via _afunc
+    assert "simulated tool failure" in reported
 
 
 def test_pending_tool_names_handles_v2_and_state_inputs():

--- a/tests/unit/test_engine_resilience.py
+++ b/tests/unit/test_engine_resilience.py
@@ -187,7 +187,10 @@ def test_query_returns_fallback_on_graph_error():
 
     class _BoomGraph:
         def invoke(self, **kwargs):
-            raise RuntimeError("graph boom")
+            # Mensagem com CHAVES de propósito: se o log de fallback usasse
+            # Loguru com kwarg (exc_info=True), o `.format()` estouraria KeyError
+            # aqui e derrotaria o fallback. Guarda de regressão.
+            raise RuntimeError("graph boom {with} {braces} in error body")
 
     fake_self = SimpleNamespace(
         _graph=_BoomGraph(),


### PR DESCRIPTION
## Por que

Bug observado (Vitória, fluxo de luminária): cidadão envia um **pin de
localização** no passo de endereço → recebe o erro genérico
`❌ Desculpe, ocorreu um erro ao processar sua mensagem.` A causa próxima
(geocode sem tratamento de erro) foi corrigida no MCP (`app-mcp-server` PR #95),
mas **qualquer tool que levante exceção** reproduz o mesmo sintoma — o engine não
tinha resiliência.

Nesta versão do langgraph o `handle_tool_errors` default **só converte
`ToolInvocationError`**; exceção no corpo da tool é **re-levantada** e propaga,
derrubando o turn inteiro. Duas lacunas se somavam:

1. `Agent.query` (e variantes) não tinha rede de segurança → a exceção virava
   erro cru → erro genérico no Gateway.
2. `MonitoredToolNode` sobrescrevia `_run`/`_arun`, que o base **nunca chama** —
   o monitoramento de erro de tool estava silenciosamente morto.

## O que muda

**A — Rede de segurança (UX).** `query`/`async_query`/`stream_query`/
`async_stream_query` ganham `try/except` que devolve um fallback amigável
(guiando o cidadão pro endereço por texto) em vez de propagar. O monitoramento
**não some por causa do catch**: o erro de grafo é reportado ao interceptor
antes do fallback.

**B — Monitoramento real.** `MonitoredToolNode` passa a sobrescrever
`_func`/`_afunc` (os entry-points reais do langgraph 1.x), espelhando a
assinatura do base (`config: RunnableConfig`, `runtime: Runtime` — necessário pra
a injeção do langgraph funcionar; com `Any` quebraria em produção). Reporta nos
dois caminhos: exceção propagada **e** `ToolMessage(status="error")`. O nome da
tool é extraído do `input` cobrindo os dois formatos — **v2/Send**
(`[tool_call dict]`, path de produção) e **state** (`{messages}`) — pra o alerta
apontar qual tool falhou em vez de `unknown`. Report sync roda mesmo sem event
loop corrente (`asyncio.run` de fallback).

A e B são complementares: **A** trata a UX do cidadão, **B** dá observabilidade.

## Testes

`tests/unit/test_engine_resilience.py` (3 casos):
- `test_query_returns_fallback_on_graph_error` — A: fallback + report ao interceptor.
- `test_monitored_tool_node_reports_propagating_tool_error` — B: dentro de grafo compilado (path fiel à produção), exceção propaga e é reportada com o nome da tool.
- `test_pending_tool_names_handles_v2_and_state_inputs` — B': nome extraído nos dois formatos de input.

Suíte unit completa: **133 passed**. Revisado via `codex review --uncommitted`
(achados resolvidos; o item de `pipelines/efficacy_eval.py` é WIP de terceiros,
fora deste PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
