### PR TITLE
fix(session): reconhece "sair" como encerramento de atendimento

### DIFF
--- a/engine/session_boundary.py
+++ b/engine/session_boundary.py
@@ -40,7 +40,7 @@ from engine.text_match import is_human, message_text, normalize
 _SERVICE_NOUNS = (
     r"conta|contrato|matricula|inscricao|cadastro|plano|empresa|negocio|mei|"
     r"servico|chamado|protocolo|pedido|solicitacao|assinatura|beneficio|linha|"
-    r"cartao|divida|debito|parcelamento"
+    r"cartao|divida|debito|parcelamento|fila"
 )
 _CLOSE_PATTERNS = [
     r"\btchau\b",
@@ -54,6 +54,15 @@ _CLOSE_PATTERNS = [
     # "não preciso de mais nada" como fim, mas não "...nada além do boleto".
     r"nao preciso (de )?mais nada(?!\s+(alem|que|fora|exceto|a nao ser|so))",
     r"nao preciso de mais ajuda",
+    # "sair" como fim de atendimento ("quero sair", "sair"), com o MESMO
+    # negative-lookahead de servico de "encerrar" — pra NAO casar "sair da
+    # conta/cadastro/fila/chamado" (pedido de servico, nao fim de sessao).
+    rf"\bsair\b(?!\s+(da |do |de |a |o |um |uma |minha |meu |meus |minhas |esse |este |essa |esta )*({_SERVICE_NOUNS}))",
+    # "parar/cancelar atendimento|conversa" EXPLICITO. Bare "parar"/"cancelar"
+    # ficam de fora de proposito: colidiriam com comandos de audio ("parar o
+    # audio", "cancela audio" — ver engine/audio_mode.py) e com "cancelar o
+    # chamado" (pedido de servico).
+    r"\b(parar|cancelar)\s+(o |a |esse |este |meu |minha )?(atendimento|conversa)\b",
 ]
 _CLOSE_RE = [re.compile(p) for p in _CLOSE_PATTERNS]
 

--- a/tests/unit/test_session_boundary.py
+++ b/tests/unit/test_session_boundary.py
@@ -37,6 +37,13 @@ def _a(text="ok"):
         "até logo",
         "não preciso de mais nada",
         "não preciso de mais ajuda",
+        # "sair" como fim de atendimento (bug do teste do Bruno 2026-06-01)
+        "sair",
+        "quero sair",
+        # "parar/cancelar atendimento|conversa" explícito
+        "cancelar atendimento",
+        "parar atendimento",
+        "pode cancelar a conversa",
     ],
 )
 def test_close_intent_detected(text):
@@ -62,6 +69,15 @@ def test_close_intent_detected(text):
         "quero encerrar o parcelamento da dívida",
         # gratidão com objeto pendente não encerra
         "não preciso de mais nada além do boleto",
+        # "sair <serviço>" é PEDIDO, não fim de sessão
+        "sair da conta de luz",
+        "quero sair do cadastro",
+        "quero sair da fila de espera",
+        # "parar/cancelar áudio" é comando de áudio (audio_mode), NÃO fim de sessão
+        "parar o áudio",
+        "cancela o áudio",
+        # "cancelar <serviço>" é pedido, não fim de sessão
+        "cancelar o chamado",
     ],
 )
 def test_close_intent_not_detected(text):


### PR DESCRIPTION
## Problema (teste real do Bruno, 2026-06-01)
"sair" **não encerrava** a conversa: o bot se despedia (prompt `session_close`), mas o reset determinístico do `session_boundary` nunca disparava — `"sair"` não estava no `_CLOSE_PATTERNS`. A despedida ficava cosmética e a próxima mensagem reentrava no workflow travado (compõe com o bug do chamado SGRC).

## Fix
- Adiciona **`sair`** ao `_CLOSE_PATTERNS`, com o mesmo negative-lookahead de serviço de `encerrar` — não casa `sair da conta/cadastro/fila/chamado`.
- Adiciona **`parar|cancelar atendimento|conversa`** explícito. **Bare `parar`/`cancelar` ficam de fora de propósito**: colidiriam com comandos de áudio (`parar o áudio`, `cancela áudio` — `engine/audio_mode.py`) e com `cancelar o chamado`.
- Adiciona `fila` ao `_SERVICE_NOUNS`.
- **+11 casos de teste** cobrindo matches (`sair`, `cancelar atendimento`) e exclusões (`parar o áudio`, `sair da conta`, `sair da fila`, `cancelar o chamado`).

## Teste
`pytest tests/unit/test_session_boundary.py` → 47 passam; suíte completa 144.

Parte do [plano de correções](https://github.com/prefeitura-rio/study-sf-whatsapp-poc1/blob/main/docs/propostas/plano-correcoes-fluxo-luminaria.md) (P0-2). Reset "duro" do estado do workflow no MCP fica como follow-up (P1-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)