### PR TITLE
feat(session): instruir reset_session_state no encerramento (Fase 1)

### DIFF
--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -40,6 +40,7 @@ from src.prompt_modules import (
     media_inbound,
     media_response,
     session_close,
+    session_reset,
     video_inbound,
     vision_inbound,
     workflow_continuation,
@@ -122,6 +123,25 @@ _interactive_response_enabled = (
 _govbr_auth_raw = _getenv_or_action("ENABLE_GOVBR_AUTH", action="ignore", default="")
 _govbr_auth_enabled = (_govbr_auth_raw or "").strip().lower() != "false"
 
+# `session_reset` gate: registra a INSTRUÇÃO pra o LLM chamar a tool MCP
+# `reset_session_state` no encerramento. Mesma estratégia de
+# audio_response/media_response — sem o gate, o LLM seria instruído a chamar tool
+# não-bound e o turno de encerramento produziria erro de tool unknown. Por isso
+# este módulo é separado do `session_close` (sempre ativo, deliberadamente
+# sem-tool): a despedida continua funcionando mesmo sem a instrução de limpeza.
+#
+# Dois níveis de desligamento, com semânticas DIFERENTES (igual aos gates acima):
+#   1. 'reset_session_state' em MCP_EXCLUDED_TOOLS → desbinda a tool no deploy E
+#      remove o módulo: limpeza totalmente desligada.
+#   2. ENABLE_SESSION_RESET=false → remove só a INSTRUÇÃO do prompt. A tool, se
+#      ainda bound, segue chamável pelo modelo (a própria descrição dela orienta
+#      o uso) — é um "soft off" do nudge, não um unbind. Pra desligar de vez,
+#      use o nível 1.
+_session_reset_enabled = (
+    (_getenv_or_action("ENABLE_SESSION_RESET", action="ignore", default="true") or "true").lower() != "false"
+    and "reset_session_state" not in _excluded_tools
+)
+
 ENABLED_MODULES = [
     workflow_continuation,
     session_close,
@@ -139,6 +159,8 @@ if _interactive_response_enabled:
     ENABLED_MODULES.append(interactive_response)
 if _govbr_auth_enabled:
     ENABLED_MODULES.append(govbr_auth_gating)
+if _session_reset_enabled:
+    ENABLED_MODULES.append(session_reset)
 
 # Observability — os gates opcionais resolvem em import-time e ficam invisíveis
 # fora do sufixo de version. Logar a decisão (+ presença do flag govbr, SEM o
@@ -148,11 +170,13 @@ if _govbr_auth_enabled:
 # (ENABLE_GOVBR_AUTH=false).
 logger.info(
     "prompt_modules optional gates: audio_response={} media_response={} "
-    "interactive_response={} govbr_auth_gating={} (ENABLE_GOVBR_AUTH present={})",
+    "interactive_response={} govbr_auth_gating={} session_reset={} "
+    "(ENABLE_GOVBR_AUTH present={})",
     _audio_response_enabled,
     _media_response_enabled,
     _interactive_response_enabled,
     _govbr_auth_enabled,
+    _session_reset_enabled,
     bool((_govbr_auth_raw or "").strip()),
 )
 

--- a/src/prompt_modules/session_reset.py
+++ b/src/prompt_modules/session_reset.py
@@ -1,0 +1,59 @@
+"""
+Prompt module — limpeza de estado de workflow ao encerrar o atendimento.
+
+Complementa o módulo ``session_close`` (que faz a despedida conversacional) e o
+reset comportamental de ``engine/session_boundary.py`` (que trunca o
+``llm_input_messages`` na mensagem seguinte). Faltava a peça do **estado de
+workflow multi-step no MCP**: o ``StateManager`` (luminária, poda, IPTU…) não era
+limpo no encerramento, então um workflow incompleto sobrevivia ao "tchau" e era
+retomado na próxima mensagem (loop relatado em teste de campo). Este módulo
+instrui o LLM a chamar a tool MCP ``reset_session_state`` quando confirma o
+encerramento, fechando esse gap ponta a ponta.
+
+Por que um módulo SEPARADO do ``session_close`` (e não uma instrução embutida):
+``session_close`` é **sempre ativo e deliberadamente sem-tool** ("não chama tool,
+não há risco de instruir tool não-bound"). Instruir ``reset_session_state`` lá
+quebraria esse invariante quando a tool estiver fora. Aqui o gating segue o MESMO
+padrão de ``audio_response`` / ``media_response`` / ``interactive_response``: o
+módulo só entra em ``ENABLED_MODULES`` quando ``reset_session_state`` NÃO está em
+``MCP_EXCLUDED_TOOLS`` e o kill-switch ``ENABLE_SESSION_RESET`` não é ``false``.
+
+Os dois sinais têm semânticas distintas (ver comentário em ``__init__.py``):
+excluir a tool (``MCP_EXCLUDED_TOOLS``) a desbinda E remove o módulo; o
+kill-switch sozinho remove só a INSTRUÇÃO do prompt (a tool, se bound, segue
+chamável — "soft off"). Em nenhum caso o LLM é instruído a chamar tool ausente, e
+a despedida (``session_close``) continua funcionando mesmo sem a instrução.
+
+Segurança: o alvo do reset é SEMPRE o telefone autenticado do thread. O
+``user_id`` que o LLM passa é sobrescrito pelo engine
+(``engine/agent.py::_inject_thread_id_in_user_id_params``, genérico para todas as
+tools e os params ``user_id``/``user_number``) — o modelo não controla o alvo,
+mesma garantia já usada pelo ``multi_step_service``.
+
+Idempotência/concorrência (Flow tardio, tool em voo, disparo duplo) é endereçada
+na Fase 2 do redesenho (``session_epoch``). Este módulo é a Fase 1: fecha o
+sintoma sem depender do epoch.
+"""
+
+MODULE_NAME = "session_reset"
+
+MODULE_PROMPT = """\
+## Limpeza de estado ao encerrar (reset_session_state)
+
+Quando você **confirmar o encerramento do atendimento** (intenção clara de
+finalizar reconhecida na seção "Encerramento de atendimento", e já resolvida a
+decisão de concluir ou cancelar qualquer workflow ativo), chame a tool
+`reset_session_state` para limpar o estado de workflow que tenha ficado em aberto
+(formulário a meio, etapa aguardando campo). Sem isso, um workflow incompleto
+sobrevive ao encerramento e é retomado por engano na próxima mensagem do cidadão.
+
+- Passe `user_id` como nas demais tools — o sistema o substitui pelo telefone
+  autenticado da conversa (você não escolhe o alvo do reset).
+- Chame **uma única vez**, no momento do encerramento. Não chame em respostas
+  comuns nem no meio de um atendimento em andamento.
+- O resultado é **interno**: NÃO mencione "limpei seu estado" nem o status da
+  tool ao cidadão. Apenas siga com a despedida calorosa da seção de encerramento.
+- Se o cidadão pediu pra **concluir** o workflow ativo (não cancelar), NÃO chame
+  esta tool ainda — retome o workflow normalmente; o reset só vale quando a
+  conversa realmente termina.
+"""

--- a/src/prompt_modules/session_reset.py
+++ b/src/prompt_modules/session_reset.py
@@ -25,10 +25,11 @@ chamável — "soft off"). Em nenhum caso o LLM é instruído a chamar tool ause
 a despedida (``session_close``) continua funcionando mesmo sem a instrução.
 
 Segurança: o alvo do reset é SEMPRE o telefone autenticado do thread. O
-``user_id`` que o LLM passa é sobrescrito pelo engine
-(``engine/agent.py::_inject_thread_id_in_user_id_params``, genérico para todas as
-tools e os params ``user_id``/``user_number``) — o modelo não controla o alvo,
-mesma garantia já usada pelo ``multi_step_service``.
+``user_id`` que o LLM passa é sobrescrito pelo engine — ver
+``_inject_thread_id_in_user_id_params`` em ``<repo-root>/engine/agent.py`` (path
+relativo à RAIZ do repo, não a ``src/``; o hook é genérico para todas as tools e
+os params ``user_id``/``user_number``). O modelo não controla o alvo — mesma
+garantia já usada pelo ``multi_step_service``.
 
 Idempotência/concorrência (Flow tardio, tool em voo, disparo duplo) é endereçada
 na Fase 2 do redesenho (``session_epoch``). Este módulo é a Fase 1: fecha o

--- a/tests/unit/test_prompt_modules.py
+++ b/tests/unit/test_prompt_modules.py
@@ -14,6 +14,7 @@ from src.prompt_modules import (
     govbr_auth_gating,
     media_inbound,
     session_close,
+    session_reset,
     vision_inbound,
     workflow_continuation,
 )
@@ -506,3 +507,80 @@ def test_session_close_logout_after_workflow_resolution():
     p = session_close.MODULE_PROMPT.lower()
     assert "logout" in p
     assert "depois" in p
+
+
+# ---------- session_reset (limpeza de estado de workflow ao encerrar) ----------
+
+
+def test_session_reset_module_has_required_attributes():
+    """session_reset segue o contrato MODULE_NAME/MODULE_PROMPT."""
+    assert hasattr(session_reset, "MODULE_NAME")
+    assert hasattr(session_reset, "MODULE_PROMPT")
+    assert isinstance(session_reset.MODULE_NAME, str)
+    assert isinstance(session_reset.MODULE_PROMPT, str)
+
+
+def test_session_reset_module_name_is_stable():
+    """MODULE_NAME vira sufixo no version (e em logs OTel) — não pode mudar
+    silenciosamente."""
+    assert session_reset.MODULE_NAME == "session_reset"
+
+
+def test_session_reset_prompt_names_the_tool():
+    """Guard contra deleção do nome EXATO da tool MCP — sem ele o LLM não sabe
+    o que chamar pra limpar o estado de workflow."""
+    assert "reset_session_state" in session_reset.MODULE_PROMPT
+
+
+def test_session_reset_prompt_passes_user_id_like_other_tools():
+    """O alvo é o telefone autenticado (o engine sobrescreve o user_id). O
+    prompt deve instruir a passar user_id como nas demais tools — se instruísse
+    a NÃO passar, a tool-call omitiria o campo e o engine não teria o que
+    sobrescrever."""
+    p = session_reset.MODULE_PROMPT.lower()
+    assert "user_id" in p
+
+
+def test_session_reset_prompt_is_internal_only():
+    """O resultado da limpeza é interno — o prompt deve instruir a NÃO expor o
+    status ao cidadão (evita 'limpei seu estado' na despedida)."""
+    p = session_reset.MODULE_PROMPT.lower()
+    assert "não mencione" in p or "interno" in p
+
+
+def test_session_reset_prompt_calls_once_on_close_only():
+    """Guard anti-spam: a tool só pode ser chamada no encerramento, uma única
+    vez — não em respostas comuns nem no meio de um atendimento."""
+    p = session_reset.MODULE_PROMPT.lower()
+    assert "uma única vez" in p or "uma unica vez" in p
+    assert "encerr" in p
+
+
+def test_session_reset_enabled_by_default():
+    """Default ON (opt-out), gated na tool bound — mesmo padrão de
+    audio_response/govbr. Pula se o ambiente desliga via kill-switch ou exclui a
+    tool, pra o teste refletir o gate real de runtime."""
+    from src.utils.infisical import getenv_or_action
+
+    explicitly_off = (
+        getenv_or_action("ENABLE_SESSION_RESET", action="ignore", default="") or ""
+    ).strip().lower() == "false"
+    excluded = "reset_session_state" in (
+        getenv_or_action("MCP_EXCLUDED_TOOLS", action="ignore", default="") or ""
+    )
+    if explicitly_off or excluded:
+        import pytest
+
+        pytest.skip("session_reset desligado via env (kill-switch ou tool excluída)")
+    assert session_reset in ENABLED_MODULES
+
+
+def test_session_reset_after_session_close_when_enabled():
+    """Ordem semântica: quando ativo, session_reset vem DEPOIS de session_close
+    (o LLM lê primeiro a regra de resolver workflow ativo, depois a limpeza)."""
+    names = [m.MODULE_NAME for m in ENABLED_MODULES]
+    if "session_reset" not in names:
+        import pytest
+
+        pytest.skip("session_reset desligado via env")
+    assert names.index("session_close") < names.index("session_reset")


### PR DESCRIPTION
## Por quê

Metade-engine do encerramento full-stack. O
[app-mcp-server#99](https://github.com/prefeitura-rio/app-mcp-server/pull/99)
adicionou a tool `reset_session_state` (limpa o `StateManager` do workflow no
MCP), mas faltava o **engine instruir o modelo a chamá-la** no "sair"/"tchau".
Sem isso, um workflow incompleto sobrevive ao encerramento e é retomado por
engano na próxima mensagem — o loop que o Bruno viu em teste de campo
("erro ao abrir o chamado" + "sair" não encerrando).

## O quê

Novo prompt module **`session_reset`** (`src/prompt_modules/session_reset.py`)
que instrui o LLM a chamar `reset_session_state` quando confirma o encerramento.

**Por que um módulo separado do `session_close`:** o `session_close` é
**sempre-ativo e deliberadamente sem-tool** (*"não chama tool, não há risco de
instruir tool não-bound"* — mesmo critério que mantém o logout gov.br fora dele).
Instruir a limpeza lá quebraria esse invariante quando a tool está fora. O
`session_reset` segue o **mesmo gate** de `audio_response`/`media_response`/
`interactive_response`: entra em `ENABLED_MODULES` só quando
`reset_session_state` ∉ `MCP_EXCLUDED_TOOLS` **e** `ENABLE_SESSION_RESET != false`.
A despedida (`session_close`) continua funcionando mesmo com a limpeza desligada.

**Dois níveis de desligamento (documentados, achado de review):**
- `reset_session_state` em `MCP_EXCLUDED_TOOLS` → desbinda a tool no deploy **e**
  remove o módulo: limpeza **totalmente** off.
- `ENABLE_SESSION_RESET=false` → remove só a **instrução** do prompt. A tool, se
  bound, segue chamável pela própria descrição — **"soft off"** do nudge, não um
  unbind. (Mesma propriedade dos gates `audio_response`/`media_response`; não
  acoplei `deploy.py` pra manter consistência com o padrão.)

## Segurança

O alvo do reset é **sempre o telefone autenticado do thread**: o engine
sobrescreve qualquer `user_id` que o modelo passe, em
`engine/agent.py::_inject_thread_id_in_user_id_params` (genérico p/ todas as
tools). O modelo não controla o alvo — mesma garantia do `multi_step_service`.

## Escopo / sequência

- **Fase 1** (este PR + #99 do MCP): fecha o sintoma do Bruno ponta a ponta.
- **Fase 2** (`session_epoch`): idempotência fina — Flow submetido tarde, tool em
  voo, disparo duplo. Não coberta aqui de propósito.
- Plano: [`docs/propostas/plano-encerramento-sessao.md`](https://github.com/prefeitura-rio/study-sf-whatsapp-poc1/blob/staging/docs/propostas/plano-encerramento-sessao.md).

## Testes

`tests/unit/test_prompt_modules.py`: **+8 testes** do `session_reset` (contrato,
nome estável, nome da tool, `user_id` passado, interno-only, chamada-única,
default-on gated, ordem após `session_close`). Suíte unit: **153 passed**.

## Dependência

Requer o MCP #99 deployado (tool `reset_session_state` bound). Sem ela, o gate
deve excluir a tool via `MCP_EXCLUDED_TOOLS` (ou o módulo instruiria uma tool
ausente — daí o gate).
