### PR TITLE
fix(prompt): não emitir texto após build_whatsapp_flow_envelope (Flow descartado)

### DIFF
--- a/src/prompt_modules/interactive_response.py
+++ b/src/prompt_modules/interactive_response.py
@@ -105,6 +105,7 @@ ASSISTANT (tool call): build_whatsapp_flow_envelope(
 - **NUNCA** ponha endereço ou CPF em `prefill_data` — o endereço é perguntado depois, na conversa (workflow), não no Flow.
 - **NÃO chame `send_whatsapp_flow(user_number, service_type)` neste prompt** — risco de hallucination de número. Veja nota acima.
 - **Caption livre no body** — use `body` pra contextualizar, não pra duplicar o texto dos botões/rows. Cidadão vê body + lista; redundância polui.
+- **NÃO escreva texto DEPOIS de `build_whatsapp_flow_envelope` / `send_whatsapp_buttons` / `send_whatsapp_list`.** O envelope que a tool retorna **É** a mensagem entregue ao cidadão (o texto fica no `body` da tool). **Encerre o turno logo após a tool call.** Uma mensagem de texto adicional depois faz o **interativo ser DESCARTADO** — o cidadão recebe só o texto, sem o Flow/botões (a mensagem de texto sobrescreve o envelope no caminho de entrega engine→gateway→Mule). NÃO "confirme", NÃO repita o body, NÃO adicione nada após a tool.
 
 ### Como o cidadão responde
 


### PR DESCRIPTION
## O quê

Regra dura no `interactive_response`: o agente **NÃO escreve texto depois** de
`build_whatsapp_flow_envelope` / `send_whatsapp_buttons` / `send_whatsapp_list` — o
envelope da tool **É** a mensagem entregue; encerra o turno após a tool call.

## Por quê (confirmado em log de produção)

Turno de luminária no engine `507`: o engine chamou `build_whatsapp_flow_envelope`
corretamente (envelope válido, `flow_token`), **mas emitiu um texto depois** → o
interativo foi **DESCARTADO** no caminho engine→gateway→Mule (o `flow_token` **nunca
chegou ao Mule**; o cidadão recebeu só o texto, sem o Flow). Outros turnos de Flow (sem
texto residual) chegaram ao Mule e renderizaram o card. Root cause = texto residual após
a tool do Flow.

## Revisão

code-reviewer (opus) **APPROVE** (regra escopada às 3 tools; sem conflito com o protocolo
pós-`nfm_reply` do `whatsapp_flow_inbound`); codex build OK (os P2/P3 do codex eram os
untracked `pipelines/`/`.playwright-mcp` de terceiros, fora do PR). 59 testes de prompt
verdes.

## Ativação

`/deploy staging` → engine novo → re-point Infisical (supera o `507`). Complementa o fix
de robustez do gateway (caminho B, separado) que evita o drop independente do LLM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
