### PR TITLE
fix(engine): reverte thinking_budget pra -1 (eval pegou regressão do cap 1024)

### DIFF
--- a/src/config/env.py
+++ b/src/config/env.py
@@ -57,17 +57,17 @@ ENABLE_INTERACTIVE_RESPONSE = getenv_or_action(
 
 # === LLM tuning (latency vs quality trade-offs) ===
 # THINKING_BUDGET: tokens maximos que o Gemini 2.5 Flash pode gastar em
-# chain-of-thought antes de responder. Default CAPADO em 1024 (era -1/unbounded):
-# o prompt deste bot e' fortemente escaffoldado (regras explicitas, Flow-first
-# deterministico), entao 1024 tokens de raciocinio sao amplos pras decisoes de
-# roteamento/tool e cortam ~5-15s/turn de latencia (e custo). E' so um teto — o
-# modelo usa MENOS quando nao precisa. Tunavel via env THINKING_BUDGET, mas
-# EFETIVO SO NO PROXIMO DEPLOY: o valor e' resolvido aqui em deploy-time e baked
-# no agent via cloudpickle (agent.py le do atributo, NAO do env em runtime —
-# mesma pegadinha do OTEL_SDK_DISABLED). O deploy loga o valor efetivo; medir p95
-# e qualidade no Signoz pos-deploy. Se query complexa/ambigua regredir, suba pra
-# 2048-4096 e re-deploye. 0 desliga, -1 volta ao unbounded.
-THINKING_BUDGET = int(getenv_or_action("THINKING_BUDGET", default="1024") or "1024")
+# chain-of-thought antes de responder. Default -1 (unbounded/dynamic — o modelo
+# decide quanto pensar). NAO CAPAR sem eval: a tentativa de capar em 1024
+# (engine 5038677510783500288, eval run 26984264727, v179->v180) foi
+# CATASTROFICA — token_usage -65%, tool_usage 0.79->0.01, activate_search
+# 0.81->0.08, qualidade global caindo pra ~1/4 em TODOS os datasets. O cap
+# matou o tool-calling/search do agente (sem budget pra planejar a chamada).
+# Qualquer tuning de latencia aqui PRECISA passar pelo eval-on-deploy antes de
+# promover (sweep medido 8192/4096/...), nunca chutar um teto baixo. Lido em
+# deploy-time e baked via cloudpickle (agent.py le do atributo, nao do env em
+# runtime). O deploy loga o valor efetivo. 0 desliga thinking; -1 unbounded.
+THINKING_BUDGET = int(getenv_or_action("THINKING_BUDGET", default="-1") or "-1")
 # INCLUDE_THOUGHTS: se o LLM retorna o texto de chain-of-thought no
 # response (alem da resposta final). Default true mantem traces visiveis
 # em logs/OTel pra debug. Setar false reduz payload de saida mas nao

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -27,9 +27,9 @@ def deploy(deploy_timestamp=None):
 
     # Tools will be loaded at runtime from MCP server (not at deployment time)
     # This allows deployment from local machine where MCP private network is not accessible
-    # LLM tuning vem de env vars. THINKING_BUDGET default agora e' 1024 (capado;
-    # era -1/unbounded) pra cortar latencia — ver racional em config/env.py. Suba
-    # via env (2048-4096) se query complexa regredir; o valor efetivo vai logado.
+    # LLM tuning vem de env vars. THINKING_BUDGET default -1 (unbounded) — capar
+    # baixo derruba tool-calling/qualidade (eval 26984264727 reprovou 1024). Nao
+    # mexer sem eval-on-deploy. Ver racional em config/env.py; valor efetivo logado.
     local_agent = Agent(
         model=model,
         system_prompt=system_prompt,


### PR DESCRIPTION
## Reverte o cap de thinking_budget (1024 → -1) — o eval pegou regressão global severa

O eval-on-deploy (run `26984264727`, v179→v180 no engine `5038677510783500288`) **reprovou** com regressão GLOBAL severa, causada pelo cap `THINKING_BUDGET=1024` (#13b):

| métrica | v179 | v180 | |
|---|---|---|---|
| `token_usage_total` (memory) | 5342 | **1837** | **−65,6%** |
| `equipments_tools` | 0.79 | **0.01** | tool-calling colapsou |
| `activate_search` | 0.81 | **0.08** | parou de buscar |
| `critical_fact_accuracy` | 0.68 | 0.22 | |
| `clarity` | 0.72 | 0.16 | |
| `response_quality` | 0.94 | 0.39 | |

~13 métricas em **todos** os datasets caíram pra ~1/4. A queda de −65% em tokens é a assinatura direta do cap; o colapso de tool/search é o modelo sem budget pra planejar a chamada. Erros gerais seguem ~0 (responde, mas raso, sem tool).

As mudanças de prompt da leva (vision-safety/qty/Flow-first-cede) são localizadas em luminária/visão e não têm caminho mecânico pra derrubar disaster/memory/equipments globalmente nem cortar tokens — só um parâmetro **global** tem esse alcance. Atribuível ao cap.

**Reverte o default pra `-1`** (provado-bom). **Mantém** o resto da leva (#4/#2b/#8) e o log do tuning efetivo. Latência (#13b) → sweep MEDIDO via eval depois, nunca chutar teto baixo. code-reviewer opus: "ship it, fix forward".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
