### PR TITLE
feat(prompt-modules): emoji na entrada + endereço do histórico (feedback Bruno/Gabs POC1)

### DIFF
--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -35,6 +35,7 @@ from loguru import logger
 from src.prompt_modules import (
     audio_inbound,
     audio_response,
+    emoji_input,
     govbr_auth_gating,
     interactive_response,
     media_inbound,
@@ -145,6 +146,7 @@ _session_reset_enabled = (
 ENABLED_MODULES = [
     workflow_continuation,
     session_close,
+    emoji_input,
     media_inbound,
     vision_inbound,
     audio_inbound,

--- a/src/prompt_modules/emoji_input.py
+++ b/src/prompt_modules/emoji_input.py
@@ -1,0 +1,61 @@
+"""
+Prompt module — interpretação de emojis na ENTRADA do cidadão.
+
+Emojis enviados pelo cidadão (dentro de um texto ou sozinhos) chegam crus ao
+modelo — não há strip/normalização no caminho gateway→engine. O Gemini em geral
+entende emoji, mas o comportamento não era especificado: faltava instrução pra
+tratar emojis comuns como SINAIS de entrada (confirmação, negação, intenção de
+localização, escolha de opção) de forma consistente.
+
+Escopo: SÓ interpretação de emoji na entrada. O uso de emoji na SAÍDA do bot é
+regido pelo prompt base / outros módulos (ex: ``audio_response`` evita emoji em
+TTS) — não é tocado aqui.
+
+Conservador por design: interpreta no CONTEXTO do último turno do bot, não trata
+emoji decorativo como comando, e manda perguntar quando o sentido é ambíguo — pra
+não sobre-interpretar num canal oficial da Prefeitura.
+
+Reações de emoji do WhatsApp (long-press → reagir a uma mensagem) são um caso
+SEPARADO: hoje a reação não chega ao engine (o gateway rejeita o
+``message_type=reaction``). Cobrir isso exige mudança em Mule + gateway, fora
+deste módulo de prompt.
+
+Sempre ativo (sem flag): não instrui a chamar nenhuma tool, então não há risco de
+tool não-bound — mesmo critério de ``workflow_continuation`` / ``session_close``.
+"""
+
+MODULE_NAME = "emoji_input"
+
+MODULE_PROMPT = """\
+## Interpretação de emojis enviados pelo cidadão (entrada)
+
+O cidadão pode responder com emojis — sozinhos ou dentro de uma frase. **Um emoji
+é uma mensagem real, não ruído: interprete-o no contexto do seu último turno**,
+como faria com texto.
+
+### Sinais comuns (sempre lendo pelo contexto)
+- 👍 👌 ✅ 🆗 🙏 — **confirmação / "sim"**, quando vêm como resposta a uma
+  pergunta de sim/não ou a um pedido de confirmação (ex: você perguntou "confirma
+  o endereço?" e o cidadão responde "👍" → trate como "sim" e siga o fluxo).
+- 👎 ❌ 🚫 — **negação / "não"**, no mesmo contexto.
+- 📍 🗺️ — sinal de **localização**, mas **só** quando o seu último turno pediu ou
+  ofereceu endereço/localização (ex: você perguntou "qual o endereço?"). Fora desse
+  contexto, trate como decorativo — não ofereça "me manda sua localização" por
+  causa de um emoji solto.
+- 1️⃣ 2️⃣ 3️⃣ (números em emoji) — **escolha da opção** correspondente, quando você
+  ofereceu uma lista numerada.
+- 💡 🔦 — pista de **iluminação pública / luminária** (trate como um relato desse
+  tema e siga o fluxo normal de luminária).
+
+### Regras
+- **Não ignore** um emoji isolado — ele responde ao seu último turno; aja sobre
+  ele em vez de pedir "manda em texto".
+- **Emoji decorativo dentro de uma frase NÃO é comando.** "Resolvido, obrigado 😊"
+  é um agradecimento; "minha rua tá escura 😩" é um relato, não um comando de
+  localização. Use o texto como sinal principal e o emoji como reforço de tom.
+- **Quando o sentido for genuinamente ambíguo** (ex: um emoji solto que não
+  responde claramente a nada), **faça uma pergunta curta** em vez de adivinhar
+  ("Desculpa, não entendi bem — você quer confirmar ou prefere mudar algo?").
+- Isto vale pra **entrada**; não muda como você usa (ou evita) emoji nas suas
+  próprias respostas.
+"""

--- a/src/prompt_modules/workflow_continuation.py
+++ b/src/prompt_modules/workflow_continuation.py
@@ -55,4 +55,45 @@ Protocolo:
    novo workflow (o anterior fica inativo, mas pode ressurgir — prefira o reset).
 4. Se não: pergunte o que quer fazer — pode ser que queira tratar os dois
    separadamente em sequência. Mantenha o workflow ativo até resolução.
+
+## Capturar o endereço do histórico ao coletar endereço
+
+Quando o workflow ativo chega no passo de **endereço** (ex: retorno do
+`multi_step_service` pedindo "qual o endereço?" / "confirme o endereço"), **antes
+de perguntar do zero, revise o histórico desta conversa** e reaproveite o que o
+cidadão já disse — mesmo que tenha dito **fora** do passo de endereço (ex:
+mencionou a rua no primeiro relato, soltou o número num turno depois, citou o
+bairro de passagem).
+
+Protocolo:
+
+1. **Junte os pedaços.** Monte a melhor string de endereço possível a partir de
+   TODOS os fragmentos já ditos no histórico (logradouro + número + bairro +
+   referências). Não descarte um pedaço só porque veio antes do passo de
+   endereço.
+2. **Se já dá pra montar um endereço, passe-o direto** no `payload` do
+   `multi_step_service` do workflow ativo, no campo `endereco` (mesma chave que o
+   Flow usa; `address` também é aceito) — em vez de re-perguntar. O próprio
+   workflow geocoda e pede a confirmação, então **neste passo** você não precisa
+   chamar `validate_address` antes: o canal de endereço é o `payload` do
+   `multi_step_service`. (Vale só pra o passo de endereço do workflow ativo — o
+   `validate_address` avulso, em mídia/áudio pré-Flow, continua valendo onde já
+   está documentado.) É o "basta chamar a tool".
+3. **Se faltar só um campo** (ex: tem rua e bairro mas falta o número), pergunte
+   **só o que falta** ("Qual o número?") e então mande a string **consolidada**
+   (rua + número + bairro) no `payload` — não peça o endereço inteiro de novo.
+4. **Atualize conforme chega informação nova.** Se, depois de já ter um endereço,
+   o cidadão corrigir ou completar (ex: "na verdade é o 250, não o 150"), monte a
+   string atualizada e re-envie no `payload` — o dado mais recente é o
+   autoritativo.
+
+Re-perguntar um endereço que o cidadão já forneceu (mesmo em pedaços) quebra
+confiança. Reaproveite o histórico sempre.
+
+**Respeite o Flow-first da luminária:** isto vale só **depois** de o cidadão
+submeter o Flow (`nfm_reply`), quando o workflow já está coletando o endereço por
+texto — **nunca** pra pré-preencher o Flow nem pra perguntar/validar o endereço
+**antes** do Flow. Pra `reparo_luminaria`, o endereço continua sendo tratado só
+após a submissão do Flow (ver "Resposta interativa"); o que muda aqui é que,
+nesse passo pós-Flow, você reaproveita o histórico em vez de perguntar do zero.
 """

--- a/tests/unit/test_prompt_modules.py
+++ b/tests/unit/test_prompt_modules.py
@@ -11,6 +11,7 @@ tests pós-deploy em staging.
 from src.prompt_modules import compose, ENABLED_MODULES
 from src.prompt_modules import (
     audio_inbound,
+    emoji_input,
     govbr_auth_gating,
     interactive_response,
     media_inbound,
@@ -475,6 +476,27 @@ def test_workflow_continuation_prompt_handles_sgrc_retry():
     assert "nunca volte pro flow" in p  # proíbe explicitamente reabrir o Flow
 
 
+def test_workflow_continuation_prompt_enriches_address_from_history():
+    """No passo de endereço, reaproveitar fragmentos já ditos no histórico (em
+    vez de re-perguntar) e passar a string consolidada no payload — o "basta
+    chamar a tool" do feedback do Bruno (POC1 #5)."""
+    p = workflow_continuation.MODULE_PROMPT.lower()
+    assert "histórico" in p
+    assert "endereço" in p
+    assert "basta chamar a tool" in p
+    assert "só o que falta" in p  # pede só o campo faltante, não o endereço todo
+    assert "multi_step_service" in p
+
+
+def test_workflow_continuation_address_history_respects_flow_first():
+    """A captura do histórico vale só pós-submissão do Flow (nfm_reply) — nunca
+    pra pré-preencher/validar endereço antes do Flow na luminária."""
+    p = workflow_continuation.MODULE_PROMPT
+    low = p.lower()
+    assert "nfm_reply" in p, "Falta o sinal de submissão do Flow"
+    assert "flow-first" in low, "Falta a salvaguarda explícita do Flow-first"
+
+
 def test_interactive_response_continuation_precedence_over_flow_first():
     """O Flow-first NÃO pode reabrir o Flow quando há atendimento de luminária
     em curso (pós-nfm_reply): a continuação tem precedência."""
@@ -642,3 +664,62 @@ def test_session_reset_after_session_close_when_enabled():
 
         pytest.skip("session_reset desligado via env")
     assert names.index("session_close") < names.index("session_reset")
+
+
+# ---------- emoji_input (interpretação de emoji na entrada) ----------
+
+
+def test_emoji_input_module_has_required_attributes():
+    """emoji_input segue o contrato MODULE_NAME/MODULE_PROMPT."""
+    assert hasattr(emoji_input, "MODULE_NAME")
+    assert hasattr(emoji_input, "MODULE_PROMPT")
+    assert isinstance(emoji_input.MODULE_NAME, str)
+    assert isinstance(emoji_input.MODULE_PROMPT, str)
+
+
+def test_emoji_input_module_name_is_stable():
+    """MODULE_NAME vira sufixo no version (e em logs OTel) — não pode mudar
+    silenciosamente."""
+    assert emoji_input.MODULE_NAME == "emoji_input"
+
+
+def test_emoji_input_enabled_by_default():
+    """Sempre ativo (sem flag): não chama tool, não há risco de tool não-bound —
+    mesmo critério de workflow_continuation / session_close."""
+    assert emoji_input in ENABLED_MODULES
+
+
+def test_emoji_input_before_media_modules_in_enabled():
+    """Regra conversacional geral entra antes dos módulos de mídia que produzem
+    respostas de etapa (mesma lógica de session_close)."""
+    names = [m.MODULE_NAME for m in ENABLED_MODULES]
+    assert "emoji_input" in names
+    assert names.index("emoji_input") < names.index("media_inbound")
+
+
+def test_emoji_input_interprets_confirmation_and_negation():
+    """Guard: emoji de confirmação/negação deve ser interpretado como sim/não no
+    contexto — núcleo do feedback do Bruno (POC1 #6)."""
+    p = emoji_input.MODULE_PROMPT
+    low = p.lower()
+    assert "👍" in p
+    assert "confirmação" in low
+    assert "negação" in low
+    assert "contexto" in low  # sempre lendo pelo contexto do último turno
+
+
+def test_emoji_input_is_conservative():
+    """Conservador: emoji decorativo não é comando e, quando ambíguo, pergunta —
+    evita sobre-interpretar num canal oficial."""
+    p = emoji_input.MODULE_PROMPT.lower()
+    assert "decorativo" in p and "não é comando" in p
+    assert "ambígu" in p and "pergunta curta" in p
+
+
+def test_emoji_input_scoped_to_input_not_output():
+    """O módulo é só sobre ENTRADA — deve AFIRMAR que não muda o uso de emoji na
+    saída (regido pelo prompt base / audio_response). Pina a cláusula de saída em
+    si: sem ela, alguém poderia remover o escopo sem o teste perceber."""
+    p = emoji_input.MODULE_PROMPT.lower()
+    assert "entrada" in p
+    assert "próprias respostas" in p  # cláusula que isola o escopo da SAÍDA


### PR DESCRIPTION
Tier-1 do feedback do Bruno/Gabs sobre a POC1 — **isolado** (ortogonal, prompt-only, eval-neutro):

- **emoji_input** (novo módulo): interpreta emoji na entrada como sinais (👍=sim, 📍=localização-no-contexto, 1️⃣=opção, 💡=luminária), conservador (decorativo≠comando, ambíguo→pergunta).
- **workflow_continuation**: captura endereço do histórico no passo de coleta (pós-Flow), respeitando Flow-first.

231→ na verdade 9 testes novos, code-reviewer opus limpo. **Não inclui** o overnight #105 (que reprovou o eval por regressão nos serviços não-luminária — ficou em rework). Branch limpo em eb322d5 = 33ef866 + Tier-1.