### PR TITLE
fix(prompt): re-landa fatos oficiais de luminária (recall factual / #104)

### DIFF
--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -39,6 +39,7 @@ from src.prompt_modules import (
     govbr_auth_gating,
     interactive_general,
     interactive_response,
+    luminaria_service_facts,
     media_inbound,
     media_response,
     session_close,
@@ -144,7 +145,17 @@ _session_reset_enabled = (
     and "reset_session_state" not in _excluded_tools
 )
 
+# `luminaria_service_facts`: fatos oficiais do reparo de luminaria (prazos 3/4
+# dias corridos, Light 0800 p/ falta de energia, e — central — preservar
+# LITERALMENTE prazo/defeito/local/quantidade/endereco em retomadas). ESTÁTICO e
+# sempre-on, e ANTES de workflow_continuation, pra que retomadas factuais ("qual o
+# prazo mesmo?") peguem o fix mesmo fora do gate dinâmico de luminária. Conteúdo
+# auto-escopado por contexto ("use quando o contexto recente for luminária";
+# "se a retomada falar de outro serviço, não aplique"). Re-land do #104 — fix do
+# `critical_fact_accuracy` (eval #104: 0.70-0.73 vs baseline 0.68 sobre o mesmo
+# v180; o engine sem ele ficava em 0.60).
 ENABLED_MODULES = [
+    luminaria_service_facts,
     workflow_continuation,
     session_close,
     emoji_input,

--- a/src/prompt_modules/luminaria_service_facts.py
+++ b/src/prompt_modules/luminaria_service_facts.py
@@ -1,0 +1,38 @@
+"""
+Modulo de prompt: fatos oficiais do servico de reparo de luminaria.
+
+Escopo propositalmente estreito: ancora somente prazos de iluminacao publica
+usados em retomadas e perguntas informacionais durante o fluxo de luminaria.
+"""
+
+MODULE_NAME = "luminaria_service_facts"
+
+MODULE_PROMPT = """
+## Fatos oficiais — reparo de luminaria
+
+Use estes fatos quando o contexto recente for reparo de luminaria/iluminacao
+publica, inclusive durante o WhatsApp Flow ou antes do cidadao enviar endereco.
+Eles tambem valem para retomadas como "qual e o prazo mesmo?", "qual o prazo de
+atendimento?" ou "quanto tempo leva?".
+
+1. Reparo de luminaria comum — luminaria apagada, piscando, acesa de dia,
+   pendurada, danificada, fraca, com ruido ou grupo de luminarias com esses
+   defeitos: o prazo oficial e **ate 3 dias corridos**.
+2. Reparo de cabo/fios de iluminacao publica — fios caidos, pendurados,
+   desnivelados, frouxos, expostos, faiscando, queimando ou furto/roubo de fios:
+   a retirada de risco e imediata quando houver risco, e o reparo/atendimento
+   tem prazo oficial de **ate 4 dias corridos**.
+3. Nunca troque esses prazos por "dias uteis". Se precisar mencionar a unidade,
+   diga sempre "dias corridos".
+4. Para perguntas diretas de prazo dentro desse contexto, responda com o prazo
+   acima diretamente; nao chame google_search apenas para confirmar esse fato.
+5. Se a mensagem indicar falta de energia em casas/predios ou semaforo apagado,
+   explique que nao e reparo de luminaria da RIOLUZ e oriente a Light pelo
+   0800 0210196, mantendo o fluxo de luminaria apenas se o problema for de
+   iluminacao publica.
+6. Em retomadas dentro deste contexto ("qual era mesmo?", "qual o prazo mesmo?",
+   "o que eu tinha que fazer?"), releia o historico recente e preserve
+   literalmente os dados de luminaria ja mencionados: prazo, defeito, local,
+   quantidade e endereco. Se a retomada falar de outro servico, nao aplique
+   estes fatos de luminaria.
+"""

--- a/tests/unit/test_prompt_modules.py
+++ b/tests/unit/test_prompt_modules.py
@@ -19,6 +19,7 @@ from src.prompt_modules import (
     govbr_auth_gating,
     interactive_general,
     interactive_response,
+    luminaria_service_facts,
     media_inbound,
     session_close,
     session_reset,
@@ -106,6 +107,43 @@ def test_compose_with_no_modules_is_passthrough(monkeypatch):
 
 
 # ---------- contract dos módulos individuais ----------
+
+
+def test_luminaria_service_facts_module_name_is_stable():
+    """MODULE_NAME vira sufixo no version e deve ser estavel."""
+    assert luminaria_service_facts.MODULE_NAME == "luminaria_service_facts"
+    assert isinstance(luminaria_service_facts.MODULE_PROMPT, str)
+
+
+def test_luminaria_service_facts_prompt_anchors_official_deadlines():
+    """Prazos de luminaria nao podem depender de busca livre instavel."""
+    p = luminaria_service_facts.MODULE_PROMPT.lower()
+    assert "3 dias corridos" in p
+    assert "4 dias corridos" in p
+    assert "acesa de dia" in p
+    assert "furto/roubo de fios" in p
+    assert "nunca troque" in p
+    assert "dias uteis" in p
+    assert "nao chame google_search" in p
+
+
+def test_luminaria_service_facts_preserves_luminaria_followups_only():
+    """Retomadas ficam protegidas sem ativar regra geral fora de luminaria."""
+    p = luminaria_service_facts.MODULE_PROMPT.lower()
+    assert "retomadas dentro deste contexto" in p
+    assert "preserve" in p
+    assert "prazo" in p
+    assert "defeito" in p
+    assert "endereco" in p
+    assert "outro servico" in p
+    assert "nao aplique" in p
+
+
+def test_luminaria_service_facts_ordered_before_workflow_modules():
+    """Facts de luminaria devem anteceder regras operacionais de Flow/workflow."""
+    assert ENABLED_MODULES.index(luminaria_service_facts) < ENABLED_MODULES.index(
+        workflow_continuation
+    )
 
 
 def test_media_inbound_module_has_required_attributes():


### PR DESCRIPTION
## Re-land do #104 — fatos oficiais de luminária (recall factual)

**Eu fechei o #104 por engano como "superseded pelo #105". Está errado:** são fixes **ortogonais**.

- **#104** (este re-land) corrige a regressão de **`critical_fact_accuracy`** em retomadas conversacionais ("qual o prazo mesmo?", "qual era o defeito?"), onde o agente **recalculava e trocava dados literais** já ditos.
- **#105** mexe na orientação interativa (buttons/list/Flow) — **outra dimensão**. Só o #105 foi landado; o recall factual ficou pra trás.

### Prova (apples-to-apples, mesmo base v180)
- Commits do #104 são de **06-06**, *depois* do v180 do Gabs (02-06) → o eval do #104 rodou sobre o **mesmo** base-prompt do engine live.
- Eval do #104 iterou `critical_fact_accuracy` **0.54 → 0.61 → 0.70/0.71/0.73** (acima do baseline 0.68); uma rodada deu **✅ Aprovado**.
- O engine **live** (`4583967880046968832`, sem #104) está em **0.60**.

### O que entra (mínimo, conflict-free)
- `src/prompt_modules/luminaria_service_facts.py` — módulo novo (verbatim do #104): prazos oficiais (**3 dias corridos** luminária / **4 dias** fios), Light **0800 0210196** pra falta de energia, e — central — **item 6: preservar literalmente prazo/defeito/local/quantidade/endereço em retomadas**.
- Registro **estático/sempre-on** em `ENABLED_MODULES`, **antes** de `workflow_continuation` — retomadas factuais podem cair fora do gate dinâmico de luminária, então o fix precisa estar no prompt global. Conteúdo **auto-escopado por contexto** ("use quando o contexto recente for luminária"; "se a retomada falar de outro serviço, não aplique").
- 4 testes unitários do módulo. Suíte: **240 passed**.

### O que fica de fora (follow-up)
As mudanças do #104 em `interactive_response.py` (roteamento fios/furto Flow-first) **conflitam com o rework do #105** e ficam pra PR separado.

### Caveat honesto (por isso o gate)
Algumas rodadas do #104 cutucaram `equipments_categories/tools` e `token_usage` pra baixo (não o `critical_fact_accuracy`). O **eval-on-deploy** — o mesmo gate que barrou o #105 — é quem confirma o saldo líquido em `servicos`/`critical_fact_accuracy` antes de promover/re-pointar. O teste unitário não alcança contaminação de domínio; só o eval.

Reviewed-by: claude-code-review
