### PR TITLE
test(prompt): trava o vetor anti-busca de fios/furto fora do interactive_general

### DIFF
--- a/tests/unit/test_prompt_modules.py
+++ b/tests/unit/test_prompt_modules.py
@@ -497,6 +497,24 @@ def test_luminaria_flow_specifics_stay_out_of_global_compose():
     assert "SEMPRE comece pelo Flow" not in augmented
 
 
+def test_interactive_general_has_no_wire_theft_antisearch_leak():
+    """Anti-regressão #104 (equipments): o roteamento de fios/furto de luminária
+    — em especial a SUPRESSÃO de busca ("não substitua por google_search") e o
+    desvio do Disque Denúncia — foi o vetor que regrediu `equipments` quando vivia
+    no módulo GLOBAL sempre-on. O dataset equipments (academias/quadras/praças/
+    postos) PRECISA de `google_search` pra categorizar; uma diretiva global
+    anti-busca enfraquecia justamente `equipments_categories`/`equipments_tools`.
+    Esse conteúdo deve viver SÓ no dinâmico de luminária (gated por turno) —
+    NUNCA aqui. (A ponte de delegação pode citar "luminária", mas não a rota de
+    fios/furto nem a supressão de busca.)"""
+    p = interactive_general.MODULE_PROMPT
+    low = p.lower()
+    assert "furto" not in low
+    assert "roubo de fios" not in low
+    assert "google_search" not in p  # o token (e portanto a supressão "não use google_search") fica fora do geral
+    assert "Disque" not in p
+
+
 def test_interactive_response_dynamic_gate_matches_luminaria_turns():
     """O pre_model_hook injeta o módulo só em turnos de luminária."""
     if not INTERACTIVE_RESPONSE_DYNAMIC_ENABLED:


### PR DESCRIPTION
Guardrail de não-regressão do #104 (sem mudar prompt → sem deploy/re-point).

O roteamento de fios/furto de luminária — em especial a supressão de busca ("não substitua por `google_search`") e o desvio do Disque Denúncia — **regrediu o dataset `equipments`** quando vivia no módulo GLOBAL sempre-on (equipments precisa de `google_search` pra categorizar academias/quadras/postos). Hoje esse conteúdo vive **só no prompt dinâmico de luminária** (gated por turno, nunca toca equipments). 

Este teste afirma que `furto`/`roubo de fios`/`google_search`/`Disque` ficam **fora** do `interactive_general` (sempre-on), travando o vetor na fonte. Complementa os testes existentes (que cobrem `flow_id`/`qty_pattern`/`defect_type`, não o vetor anti-busca). Suíte verde.

Contexto: a investigação do follow-up do #104 mostrou que o roteamento fios/furto **já está live e equipments-safe** no dinâmico (re-land via #105 rework) — não havia o que re-landar; este teste só **fecha o cadeado** pra a regressão não voltar.

Reviewed-by: claude-code-review