### PR TITLE
feat(audio): áudio contínuo p/ quem não lê — acessibilidade (POC1 #296)

### DIFF
--- a/engine/audio_mode.py
+++ b/engine/audio_mode.py
@@ -18,8 +18,10 @@ Por que assim:
 
 Distinção importante: um pedido pontual ("me responde com áudio") **não** liga o
 modo contínuo — isso é tratado por turno pelo prompt module ``audio_response``.
-O modo contínuo só liga com marcadores de continuidade ("sempre", "fica",
-"continua", "só áudio", "não precisa escrever").
+O modo contínuo liga com marcadores de continuidade ("sempre", "fica",
+"continua", "só áudio", "não precisa escrever") OU com sinais de acessibilidade
+("não sei ler", "analfabeto", "deficiente visual" — o cidadão que não lê precisa
+de áudio por necessidade, não preferência).
 """
 
 import re
@@ -55,6 +57,21 @@ _ON_PATTERNS = [
     r"nao precisa.{0,12}escrever",
     r"para de escrever",
     r"(responde|responda|me responde|fala).{0,15}sempre.{0,15}(falando|audio|voz)",
+    # Acessibilidade: cidadão que NÃO LÊ (analfabetismo / baixa visão) precisa de
+    # áudio CONTÍNUO — é necessidade, não preferência pontual, por isso liga o modo
+    # durável (reinjetado todo turno, não "reverte sozinho"). Viés pró-áudio é
+    # proposital num serviço público: o custo de não atender quem não lê supera o
+    # de gerar um áudio a mais (reversível com "volta pra texto"). POC1 #296.
+    r"nao sei ler\b",
+    r"nao sei le\b",  # coloquial "não sei lê"
+    r"nao consigo ler\b",
+    r"\bnao leio\b",
+    r"\banalfabet",  # analfabeto/a/ismo
+    r"dificuldade.{0,15}(de |pra |para )?ler\b",
+    # "deficiente visual" é inequívoco; deliberadamente NÃO incluímos "nao enxergo"
+    # — neste bot (luminária) "não enxergo nada na rua" descreve o escuro do poste,
+    # não dificuldade de leitura → seria falso-positivo no fluxo principal.
+    r"deficiente visual",
 ]
 
 _OFF_PATTERNS = [

--- a/src/prompt_modules/audio_response.py
+++ b/src/prompt_modules/audio_response.py
@@ -81,5 +81,7 @@ A resposta final inclui o texto (pra logs/audit + cidadão poder ler) E o `audio
 
 ### REGRA CRÍTICA
 
-O cidadão precisa ter pedido explicitamente. Não infira modo áudio de "pediu rapidez", "tá com pressa", "quer simples" — esses são pedidos por brevidade, não por áudio. Apenas frases explícitas tipo "áudio", "ouvir", "falar" disparam o protocolo.
+O cidadão precisa ter pedido explicitamente. Não infira modo áudio de "pediu rapidez", "tá com pressa", "quer simples" — esses são pedidos por brevidade, não por áudio. Frases explícitas tipo "áudio", "ouvir", "falar" disparam o protocolo.
+
+**Exceção de acessibilidade:** se o cidadão indicar que NÃO LÊ (ex.: "não sei ler", "sou analfabeto", "não enxergo", "tenho dificuldade de ler"), isso é uma NECESSIDADE, não uma preferência — responda em áudio e mantenha o modo contínuo. O sistema deriva isso do histórico e injeta a diretiva `MODO ÁUDIO CONTÍNUO ATIVO` (durável, reaplicada todo turno); quando ela estiver presente, siga-a mesmo que o pedido não use a palavra "áudio".
 """

--- a/tests/unit/test_audio_mode.py
+++ b/tests/unit/test_audio_mode.py
@@ -38,6 +38,66 @@ def test_on_phrases(text):
 
 
 # --------------------------------------------------------------------------- #
+# Acessibilidade (POC1 #296) — cidadão que não lê → áudio contínuo durável
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "text",
+    [
+        "não sei ler",
+        "nao sei ler",
+        "eu não sei ler nem escrever",
+        "não sei lê",
+        "não consigo ler",
+        "não leio",
+        "sou analfabeto",
+        "sou analfabeta",
+        "tenho dificuldade de ler",
+        "tenho dificuldade pra ler",
+        "sou deficiente visual",
+    ],
+)
+def test_accessibility_phrases_enable_continuous_audio(text):
+    assert derive_audio_mode([_h(text)]) is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # "não enxergo" descreve o escuro do poste neste bot — NÃO é sinal de
+        # leitura, então deliberadamente não liga áudio (evita falso-positivo no
+        # fluxo principal de luminária).
+        "minha luminária tá apagada e não enxergo nada na rua",
+        "não enxergo o poste daqui",
+        "não sei o número do poste",
+    ],
+)
+def test_dark_streetlight_phrases_do_not_enable_audio(text):
+    assert derive_audio_mode([_h(text)]) is False
+
+
+def test_accessibility_persists_across_neutral_turns():
+    """Necessidade de acessibilidade não 'reverte sozinha' (José Maurício):
+    a diretiva é derivada do histórico todo turno e persiste sem re-pedido."""
+    history = [
+        _h("não sei ler, me responde falando"),
+        _h("é na rua das laranjeiras"),
+        _h("perto do número 250"),
+    ]
+    assert derive_audio_mode(history) is True
+
+
+def test_accessibility_can_be_turned_off_explicitly():
+    """Se um ajudante passar a ler, 'volta pra texto' ainda desliga (newest wins)."""
+    history = [_h("não sei ler"), _h("pode voltar pra texto agora")]
+    assert derive_audio_mode(history) is False
+
+
+def test_reading_a_document_is_not_accessibility_trigger():
+    """'quero ler o edital' é pedido de conteúdo, não sinal de que não sabe ler."""
+    assert derive_audio_mode([_h("quero ler o edital")]) is False
+
+
+# --------------------------------------------------------------------------- #
 # derive_audio_mode — OFF / não-contínuo
 # --------------------------------------------------------------------------- #
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Por quê (POC1 #296)
QA: uma cidadã mandou áudio dizendo que **não sabia ler** e pediu resposta em áudio — o bot respondeu **em texto**. Para um serviço público, não atender quem não lê é uma falha de acessibilidade. Também: o "áudio contínuo" do José Maurício "reverteu sozinho".

## O que muda
`derive_audio_mode` (engine/audio_mode.py) — a derivação determinística e durável do modo áudio contínuo — agora reconhece **sinais de não-leitura** como gatilho ON:
- "não sei ler", "não consigo ler", "não leio", "analfabeto/a", "dificuldade de ler", "deficiente visual".
- É **necessidade, não preferência** → liga o modo CONTÍNUO (reinjetado todo turno pelo `pre_model_hook`), então **não reverte sozinho**; só desliga com "volta pra texto" (caso de um ajudante passar a ler) ou no encerramento.
- Carve-out de acessibilidade na REGRA CRÍTICA do `audio_response.py` (a diretiva injetada é autoritativa mesmo sem a palavra "áudio").

## Decisão de design (code-review pegou)
**NÃO** inclui `"não enxergo"`: neste bot de **luminária**, "não enxergo nada na rua" descreve o **escuro do poste**, não dificuldade de leitura → seria falso-positivo no fluxo principal. Mantém só `"deficiente visual"` (inequívoco). Teste-guarda trava isso.

Viés pró-áudio é **proposital + reversível**: o custo de não atender quem não lê supera o de um áudio a mais.

## Testes
`test_audio_mode.py`: +ON acessibilidade, +guarda dark-streetlight, +persistência, +OFF explícito. **256 passed** (suíte engine completa). Code-review opus aplicado (removeu o FP "não enxergo", corrigiu docstring).

## Deploy
Engine → precisa **/deploy staging** (gera novo REASONING_ENGINE_ID) + **re-point no Infisical (você)**. Vou comentar /deploy e te passo o ID + resultado da eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)