### PR TITLE
fix(engine): não duplicar texto/confirmação no multi_step_service interativo

### DIFF
--- a/src/prompt_modules/workflow_continuation.py
+++ b/src/prompt_modules/workflow_continuation.py
@@ -34,6 +34,25 @@ e o estado (defeito, local, endereco, identificacao) foi preservado — o retry 
 re-tenta a abertura, sem recomecar do zero. Se falhar de novo, informe com
 empatia e ofereca tentar mais tarde ou encerrar; nunca volte pro Flow.
 
+## NÃO escreva texto acompanhando o `multi_step_service` interativo
+
+Às vezes o `multi_step_service` responde enviando uma mensagem interativa DIRETO
+ao cidadão (botões/lista/formulário): o retorno vem como `"status":"interactive_sent"`
+com uma instrução tipo "NÃO escreva nenhuma mensagem adicional...". Nesses casos:
+
+- **NÃO emita texto no mesmo turno em que chama a tool, nem depois.** A mensagem
+  que a tool enviou (os botões + o enunciado) JÁ É a mensagem ao cidadão. Um texto
+  seu junto vira uma 2ª mensagem DUPLICADA — ex.: os botões "Como você gostaria de
+  se identificar?" seguidos de um "Opa! Você gostaria de se identificar?" redundante.
+  Encerre o turno em silêncio.
+- Como o retorno só chega DEPOIS da chamada, **não escreva a pergunta de
+  antecipação**: chame a tool primeiro e deixe o retorno decidir — `interactive_sent`
+  → silêncio; passo de texto comum → aí sim componha a resposta a partir do retorno.
+- **NÃO invente confirmações próprias** (ex.: "Confirma o envio da solicitação de
+  forma anônima?"). O workflow já tem o passo de **confirmação dos dados** (botões
+  Sim/Não) — essa é a ÚNICA confirmação. Anônimo é apenas a ausência de
+  identificação; não peça um "confirma anônimo?" extra.
+
 ## Detecção de pivot (troca de serviço mid-workflow)
 
 Se o cidadão estiver com um workflow X ativo e enviar mensagem mencionando um

--- a/tests/unit/test_prompt_modules.py
+++ b/tests/unit/test_prompt_modules.py
@@ -127,6 +127,17 @@ def test_luminaria_service_facts_prompt_anchors_official_deadlines():
     assert "nao chame google_search" in p
 
 
+def test_workflow_continuation_proibe_duplicata_e_confirma_anonimo_propria():
+    """Anti-duplicata do multi_step_service interativo + não inventar uma
+    confirmação anônima própria (queixas do device-test 2026-06-16)."""
+    p = workflow_continuation.MODULE_PROMPT.lower()
+    # regra: não escrever texto acompanhando o interactive_sent (evita 2ª msg)
+    assert "interactive_sent" in p
+    assert "duplicada" in p
+    # exemplo de confirmação que o agente NÃO deve inventar (workflow já confirma)
+    assert "confirma o envio" in p
+
+
 def test_luminaria_service_facts_preserves_luminaria_followups_only():
     """Retomadas ficam protegidas sem ativar regra geral fora de luminaria."""
     p = luminaria_service_facts.MODULE_PROMPT.lower()


### PR DESCRIPTION
## Contexto (device-test 2026-06-16)
Na **identificação**, o cidadão recebia **2 mensagens**: os botões (camada-tool) + um texto redundante do agente ("Opa! Recebi sua informação. Você gostaria de se identificar?"). O agente também inventava uma confirmação própria ("Confirma o envio... de forma anônima?").

**Causa:** o Gemini emite texto + tool-call no MESMO turno → o texto sai antes do retorno `interactive_sent`.

## Fix (prompt-only, em `workflow_continuation`)
- Quando `multi_step_service` responde com `interactive_sent`, **não escrever texto acompanhando** (a saída do tool É a mensagem) — mesmo princípio do "não escreva após o Flow".
- **Não inventar confirmações próprias** — o passo de confirmação dos dados (com botões) é a única.
- Espelha o ticket-confirm, que já fazia isso (silencioso, validado hoje sem fallback).

## Verificação
- 259 testes; eval do gate de prompt **508/508 (100%)**; codex review limpo.
- Device (pós-deploy + re-point): a identificação vem como **uma** mensagem (só os botões), sem texto duplicado nem "confirma anônimo?" extra.

## Fora desta leva
**Fix 3 (áudio no card do Flow):** o codex apontou que prompt-only NÃO entrega o áudio (entrega single-media descarta o áudio quando há Flow `return_direct`). Precisa de trabalho na entrega (Mule manda 2 mídias) — esforço à parte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)