### PR TITLE
feat(engine): botões/listas proativos confiáveis (Feature 1) + modo áudio entrega resposta completa (Feature 2b)

### DIFF
--- a/engine/audio_mode.py
+++ b/engine/audio_mode.py
@@ -32,18 +32,27 @@ from langchain_core.messages import SystemMessage
 from engine.session_boundary import current_session_messages
 from engine.text_match import is_human, message_text, normalize
 
-# Diretiva reinjetada todo turno quando o modo contínuo está ligado. Já embute a
-# regra de precedência (resumo falado em áudio + detalhes em texto) para resolver
-# o conflito com a regra "conteúdo estruturado vai em texto" do prompt module.
+# Diretiva reinjetada todo turno quando o modo contínuo está ligado. Embute a regra
+# crítica (Feature 2b): em modo áudio o WhatsApp entrega o áudio ISOLADO — o texto
+# que acompanha a resposta NÃO chega ao cidadão (Mule, webhook-flow.xml: áudio sem
+# prelúdio textual). Logo a resposta COMPLETA precisa estar falada no áudio; não
+# adianta resumir e deixar os detalhes no texto (eles se perderiam). Isso também
+# resolve o conflito com a regra "conteúdo estruturado vai em texto" do prompt module
+# (aqui a diretiva tem precedência). O 2º balão de texto pra dado crítico
+# (protocolo/URL) é trabalho deferido (gargalo Meta: 1 tipo por mensagem) — por ora
+# o próprio áudio carrega tudo.
 AUDIO_MODE_DIRECTIVE = (
     "MODO ÁUDIO CONTÍNUO ATIVO. O cidadão pediu para receber as respostas SEMPRE "
-    "em áudio até pedir o contrário. Neste turno: componha a resposta em texto "
-    "natural (sem markdown nem emoji) e chame a tool "
-    "generate_audio_response(text=<resposta>), anexando o audio_base64. "
-    "Se a resposta for longa ou tiver dados estruturados (lista rua-por-rua, "
-    "números de protocolo, links), NÃO caia só para texto: mande o ÁUDIO de um "
-    "resumo falado curto E mantenha os detalhes no texto. Só pare de gerar áudio "
-    "quando o cidadão pedir explicitamente (ex.: 'volta pra texto')."
+    "em áudio até pedir o contrário (ex.: 'volta pra texto'). Neste modo o ÁUDIO é a "
+    "ÚNICA mensagem entregue ao cidadão — o texto que acompanha a resposta NÃO chega "
+    "(o WhatsApp entrega o áudio isolado). Por isso: componha a resposta COMPLETA em "
+    "texto natural falável (sem markdown nem emoji) e chame "
+    "generate_audio_response(text=<resposta completa>), anexando o audio_base64. "
+    "TUDO que o cidadão precisa saber tem que estar FALADO no áudio — NÃO mande um "
+    "resumo curto deixando os detalhes só no texto, eles se perderiam. Se houver "
+    "dado crítico (número de protocolo, CEP, link), fale-o de forma clara e pausada "
+    "no próprio áudio (ex.: protocolo dígito a dígito). Só pare de gerar áudio "
+    "quando o cidadão pedir explicitamente."
 )
 
 # Padrões normalizados (sem acento, minúsculo). OFF é checado antes de ON por

--- a/engine/interactive_tools.py
+++ b/engine/interactive_tools.py
@@ -22,19 +22,30 @@ ALL_INTERACTIVE_TOOL_NAMES = (
 
 
 def mark_interactive_tools_return_direct(tools: Iterable[BaseTool]) -> list[BaseTool]:
-    """Stop the ReAct loop after tools whose return is the citizen-facing message."""
+    """Stop the ReAct loop after tools whose return is the citizen-facing message.
+
+    Cobre Flow (``build_whatsapp_flow_envelope``) E os interativos não-Flow
+    (``send_whatsapp_buttons`` / ``send_whatsapp_list``): o envelope que essas tools
+    retornam JÁ É a mensagem entregue ao cidadão, então o turno encerra ali. Sem o
+    ``return_direct``, o LLM podia escrever texto depois — e esse texto descartaria o
+    interativo no caminho engine→gateway→Mule (Feature 1: botões/listas proativos).
+    """
     tool_list = list(tools)
     for tool in tool_list:
-        if tool.name in INTERACTIVE_RESPONSE_TOOL_NAMES:
+        if tool.name in ALL_INTERACTIVE_TOOL_NAMES:
             tool.return_direct = True
     return tool_list
 
 
 def is_successful_interactive_tool_message(message: object) -> bool:
-    """Whether a ToolMessage is a successful citizen-facing interactive envelope."""
+    """Whether a ToolMessage is a successful citizen-facing interactive envelope.
+
+    Inclui Flow + botões/lista (``ALL_INTERACTIVE_TOOL_NAMES``): todos são respostas
+    interativas voltadas ao cidadão que encerram o turno (preview p/ eval +
+    reposicionamento como última mensagem)."""
     return (
         isinstance(message, ToolMessage)
-        and message.name in INTERACTIVE_RESPONSE_TOOL_NAMES
+        and message.name in ALL_INTERACTIVE_TOOL_NAMES
         and getattr(message, "status", None) != "error"
     )
 
@@ -43,7 +54,7 @@ def is_failed_interactive_tool_message(message: object) -> bool:
     """Whether a ToolMessage is a failed citizen-facing interactive envelope."""
     return (
         isinstance(message, ToolMessage)
-        and message.name in INTERACTIVE_RESPONSE_TOOL_NAMES
+        and message.name in ALL_INTERACTIVE_TOOL_NAMES
         and getattr(message, "status", None) == "error"
     )
 

--- a/engine/monitored_tool_node.py
+++ b/engine/monitored_tool_node.py
@@ -36,8 +36,7 @@ from langgraph.runtime import Runtime
 from engine.utils import send_general_error, make_tool_source
 from engine.log import logger
 from engine.interactive_tools import (
-    ALL_INTERACTIVE_TOOL_NAMES,
-    is_successful_interactive_tool_message,
+    NON_FLOW_INTERACTIVE_TOOL_NAMES,
     put_interactive_tool_messages_last,
 )
 
@@ -170,14 +169,18 @@ class MonitoredToolNode(ToolNode):
                 # fix 4f65686 para toda tool NÃO-interativa (multi_step_service,
                 # google_search, …), que o adapter MCP entrega como `["texto"]`.
                 # EXCEÇÃO: interativas não-Flow (buttons/list) mantêm o content em
-                # lista — ali a lista É a estrutura voltada ao cidadão.
+                # lista — ali a lista É a estrutura voltada ao cidadão. O teste é por
+                # NOME (NON_FLOW_INTERACTIVE_TOOL_NAMES), NÃO por
+                # is_successful_interactive_tool_message: com a Feature 1 (botões/lista
+                # proativos) essas tools passaram a contar como interativas
+                # bem-sucedidas (return_direct + preview), e amarrar a normalização ao
+                # is_successful as normalizaria por engano. O nome desacopla os dois.
                 # Premissa: o adapter MCP (content_and_artifact) entrega bloco
                 # único; uma tool com MÚLTIPLOS blocos de texto perderia
                 # content[1:] aqui (comportamento herdado do 4f65686).
                 if (
-                    is_successful_interactive_tool_message(message)
-                    or getattr(message, "name", None)
-                    not in ALL_INTERACTIVE_TOOL_NAMES
+                    getattr(message, "name", None)
+                    not in NON_FLOW_INTERACTIVE_TOOL_NAMES
                 ):
                     message.content = message.content[0]
                     logger.debug(

--- a/src/prompt_modules/audio_response.py
+++ b/src/prompt_modules/audio_response.py
@@ -77,7 +77,7 @@ ASSISTANT (resposta final ao cidadão):
 "Pra abrir um chamado de luminária quebrada, me passa o endereço completo, com rua, número e bairro. Depois eu confirmo os dados e abro a solicitação no sistema da Prefeitura."
 ```
 
-A resposta final inclui o texto (pra logs/audit + cidadão poder ler) E o `audio_base64` em campo separado pro Mule processar.
+A resposta final inclui o texto (pra logs/audit) E o `audio_base64` em campo separado pro Mule processar. **Atenção:** o WhatsApp entrega o áudio ISOLADO — o texto NÃO chega ao cidadão junto com a voice message. Por isso, quando você gera áudio, tudo que o cidadão precisa saber tem que estar FALADO no áudio (não deixe informação só no texto). É também por isso que dados estruturados (protocolo, links, listas) vão em TEXTO e não em áudio — exceto no modo áudio contínuo, onde a diretiva manda a resposta inteira pro áudio.
 
 ### REGRA CRÍTICA
 

--- a/tests/unit/test_interactive_tools.py
+++ b/tests/unit/test_interactive_tools.py
@@ -38,7 +38,9 @@ def list_service_options() -> list[dict[str, str]]:
     return [{"name": "luminaria"}, {"name": "poda"}]
 
 
-def test_interactive_tools_return_direct_only_for_interactive_messages():
+def test_interactive_tools_return_direct_for_all_interactive_messages():
+    """Feature 1: Flow E botões/lista recebem return_direct (encerram o turno); as
+    não-interativas (google_search) não."""
     tools = mark_interactive_tools_return_direct(
         [
             build_whatsapp_flow_envelope,
@@ -50,8 +52,8 @@ def test_interactive_tools_return_direct_only_for_interactive_messages():
 
     by_name = {tool.name: tool for tool in tools}
     assert by_name["build_whatsapp_flow_envelope"].return_direct is True
-    assert by_name["send_whatsapp_buttons"].return_direct is False
-    assert by_name["send_whatsapp_list"].return_direct is False
+    assert by_name["send_whatsapp_buttons"].return_direct is True
+    assert by_name["send_whatsapp_list"].return_direct is True
     assert by_name["google_search"].return_direct is False
 
 
@@ -136,9 +138,12 @@ def test_interactive_return_direct_keeps_interactive_tool_message_last():
     assert result["messages"][-1].name == "build_whatsapp_flow_envelope"
 
 
-def test_non_flow_interactive_tool_does_not_return_direct_or_normalize_content():
+def test_non_flow_interactive_tool_returns_direct_and_keeps_list_content():
+    """Feature 1: send_whatsapp_list recebe return_direct (encerra o loop após a
+    tool), MAS seu content em lista (a estrutura interativa voltada ao cidadão) é
+    preservado — não normalizado para content[0]."""
     tools = mark_interactive_tools_return_direct([send_whatsapp_list])
-    assert tools[0].return_direct is False
+    assert tools[0].return_direct is True
     model = _InteractiveToolCallingModel(
         tool_calls_to_emit=[
             {
@@ -153,7 +158,7 @@ def test_non_flow_interactive_tool_does_not_return_direct_or_normalize_content()
     graph = create_react_agent(model=model, tools=tools)
     result = graph.invoke({"messages": [HumanMessage(content="opções")]})
 
-    assert model.calls == 2
+    assert model.calls == 1  # return_direct encerra o loop após a tool
     tool_message = next(
         m for m in result["messages"] if isinstance(m, ToolMessage)
     )
@@ -161,7 +166,7 @@ def test_non_flow_interactive_tool_does_not_return_direct_or_normalize_content()
     assert tool_message.content == [
         {"type": "text", "text": "Escolha uma opção"}
     ]
-    assert isinstance(result["messages"][-1], AIMessage)
+    assert result["messages"][-1] is tool_message  # o interativo é a última mensagem
 
 
 def test_non_interactive_tool_list_content_is_not_normalized_in_tool_node():
@@ -412,7 +417,7 @@ def test_interactive_filter_falls_back_to_tool_content_when_args_have_no_text():
     assert filtered_result["messages"][-1].name == "build_whatsapp_flow_envelope"
 
 
-def test_interactive_filter_does_not_add_preview_for_list_body_args():
+def test_interactive_filter_adds_preview_for_list_body_args():
     result = {
         "messages": [
             HumanMessage(content="quero opções"),
@@ -461,14 +466,17 @@ def test_interactive_filter_does_not_add_preview_for_list_body_args():
         if isinstance(message, AIMessage)
         and message.additional_kwargs.get("synthetic_interactive_preview")
     ]
-    assert previews == []
-    assert isinstance(filtered_result["messages"][-2], AIMessage)
-    assert filtered_result["messages"][-2].content == ""
+    # Feature 1: a lista agora conta como interativa bem-sucedida → ganha o preview
+    # sintético (body + títulos das rows) pro eval/operador; o interativo segue last.
+    assert len(previews) == 1
+    assert "Escolha uma opção na lista." in previews[0].content
+    assert "Luminária" in previews[0].content
+    assert "Poste caído" in previews[0].content
     assert isinstance(filtered_result["messages"][-1], ToolMessage)
     assert filtered_result["messages"][-1].name == "send_whatsapp_list"
 
 
-def test_interactive_filter_does_not_add_preview_for_button_titles():
+def test_interactive_filter_adds_preview_for_button_titles():
     result = {
         "messages": [
             HumanMessage(content="continuar?"),
@@ -505,9 +513,12 @@ def test_interactive_filter_does_not_add_preview_for_button_titles():
         if isinstance(message, AIMessage)
         and message.additional_kwargs.get("synthetic_interactive_preview")
     ]
-    assert previews == []
-    assert isinstance(filtered_result["messages"][-2], AIMessage)
-    assert filtered_result["messages"][-2].content == ""
+    # Feature 1: os botões agora contam como interativa bem-sucedida → ganham o
+    # preview sintético (body + títulos dos botões); o interativo segue last.
+    assert len(previews) == 1
+    assert "Quer continuar o atendimento?" in previews[0].content
+    assert "Sim" in previews[0].content
+    assert "Não" in previews[0].content
     assert isinstance(filtered_result["messages"][-1], ToolMessage)
     assert filtered_result["messages"][-1].name == "send_whatsapp_buttons"
 


### PR DESCRIPTION
Dois itens do plano (interativos proativos + áudio pré-salvo). Ambos **engine**, mesmo ciclo de deploy+eval. Sem flag nova — **eval-gate** (decisão do usuário: direto, o eval-on-deploy valida; verde → re-point liga).

## Feature 1 — botões/listas proativos confiáveis

O prompt `interactive_general` (sempre-on) **já instrui** o LLM a usar `send_whatsapp_buttons`/`send_whatsapp_list` proativamente; o gap era confiabilidade: só o Flow tinha `return_direct`. Sem ele, após chamar essas tools o ReAct loop continuava e o LLM podia escrever texto — que **descarta** o interativo no caminho engine→gateway→Mule.

- `mark_interactive_tools_return_direct` + `is_successful`/`is_failed_interactive_tool_message` → `ALL_INTERACTIVE_TOOL_NAMES` (Flow + botões + lista): o turno encerra após a tool; elas ganham o **preview sintético** (texto pro eval/operador) + reposicionamento como última msg.
- `monitored_tool_node`: normalização de content **desacoplada** de `is_successful` (agora testa por NOME — `not in NON_FLOW_INTERACTIVE_TOOL_NAMES`), pra botões/lista manterem o content em lista (a estrutura interativa) mesmo contando como interativa bem-sucedida. Resultado de normalização idêntico ao anterior.
- 4 testes de `interactive_tools` atualizados.

## Feature 2b — modo áudio entrega a resposta COMPLETA

Em modo áudio o WhatsApp entrega o áudio **isolado** (webhook-flow.xml: sem prelúdio textual). A `AUDIO_MODE_DIRECTIVE` antiga mandava "resumo curto no áudio + detalhes no texto" → os detalhes (no texto descartado) **se perdiam**. Agora manda a resposta **completa** no áudio (dado crítico falado dígito a dígito). 2º balão de texto pra protocolo/URL = **deferido** (gargalo Meta). Módulo `audio_response` ajustado pra explicar a entrega isolada.

## Verificação
259 unit verdes; codex review limpo nas duas. **Próximo:** `/deploy staging` → eval-on-deploy → se verde, re-point Infisical (REASONING_ENGINE_ID).

🤖 Generated with [Claude Code](https://claude.com/claude-code)