### PR TITLE
fix(prompt): confirmação única de endereço em location-share

### DIFF
--- a/src/prompt_modules/media_inbound.py
+++ b/src/prompt_modules/media_inbound.py
@@ -94,12 +94,12 @@ Quando o cidadão compartilha localização pelo WhatsApp ("anexo → localizaç
    - **`validate_address(address=<texto>)`** somente se o JSON `media.address`/`media.name` já trouxer texto de endereço suficiente. Não passe latitude/longitude para `validate_address`.
    - **Outra tool explicitamente documentada como aceitando lat/lng**, se disponível.
    - Se nenhuma tool disponível aceitar coordenadas e não houver texto de endereço no JSON, explique que recebeu a localização, mas precisa confirmar o endereço em texto para continuar.
-3. **Apresente o endereço resolvido pro cidadão COM DISCLOSURE explícito da origem.** Não pergunte "Você se refere a Rua X?" — isso soa como se ele tivesse mencionado. Use formato:
+3. **Apresente o endereço resolvido pro cidadão COM DISCLOSURE explícito da origem, como AFIRMAÇÃO — NÃO pergunte "Está correto?" aqui.** Não pergunte "Você se refere a Rua X?" — isso soa como se ele tivesse mencionado. A confirmação do endereço acontece **UMA vez**, no workflow do serviço (`multi_step_service` apresenta a confirmação estruturada, com os campos logradouro/número/bairro). Perguntar "está correto?" aqui **E** lá gera **dupla confirmação** do mesmo endereço — evite. Use formato (afirmação, sem pergunta):
 
-   > Pela localização que você compartilhou, identifiquei *Rua X, número Y - Bairro*. Está correto?
+   > Pela localização que você compartilhou, identifiquei *Rua X, número Y - Bairro*.
 
-4. Aguarde confirmação. Se "sim", prossiga com esse endereço como dado confirmado no histórico do thread (importante: workflows downstream, especialmente `multi_step_service` pós-Flow, devem enriquecer payload com esse endereço — ver módulo `whatsapp_flow_inbound`).
-5. Se o cidadão corrigir ("não, é a Rua Z"), use a correção dele como endereço.
+4. Prossiga com esse endereço para o serviço ativo — o workflow (`multi_step_service`) apresentará a **confirmação estruturada** do endereço, que é o **ponto único** de confirmação/correção. Trate o endereço resolvido como o dado de endereço do thread (workflows downstream, especialmente `multi_step_service` pós-Flow, devem enriquecer o payload com ele — ver módulo `whatsapp_flow_inbound`). Se **não houver serviço ativo** (o cidadão só compartilhou a localização, sem pedido), aí sim pergunte o que ele precisa com esse endereço.
+5. Se o cidadão corrigir o endereço a qualquer momento ("não, é a Rua Z"), use a correção dele.
 
 **Nunca apresente endereço como fato consumado sem disclosure.** O cidadão precisa entender que VOCÊ resolveu a localização dele, não que ele te disse o endereço.
 


### PR DESCRIPTION
## O que

Remove a **dupla confirmação** do mesmo endereço quando o cidadão compartilha localização.

**Antes:** location → geocode → "identifiquei X. **Está correto?**" → "Sim" → workflow do serviço → "confirme os campos. **Está correto?**" → "Sim" (2 confirmações do mesmo endereço).

**Depois:** o disclosure do geocode vira **afirmação** (sem "Está correto?"); a confirmação acontece **uma vez**, na confirmação estruturada do `multi_step_service` (que mostra os campos). Mantém o disclosure de origem e a correção a qualquer momento; trata o caso sem-serviço-ativo.

## Causa-raiz
Duas camadas confirmavam o endereço de forma independente (engine `media_inbound` + MCP `multi_step_service`), sem contrato entre elas. Diagnóstico completo veio de device-test real (logs do Mule: `agent_response_empty:true, has_interactive_sent:true`).

## Validação
- codex review --uncommitted: sem regressão.
- pre-commit: passou.
- **Eval-gate: roda no /deploy** — só promover (re-point) se passar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)