### PR TITLE
fix(engine): confirmação única de endereço (dedup interativo)

### DIFF
--- a/engine/custom_react_agent.py
+++ b/engine/custom_react_agent.py
@@ -51,6 +51,7 @@ from langgraph.typing import ContextT
 from langgraph.warnings import LangGraphDeprecatedSinceV10
 from engine.log import logger
 from engine.monitored_tool_node import MonitoredToolNode
+from engine.interactive_tools import is_mss_interactive_sent_message
 
 # Error monitoring utilities (safe fallback if not available)
 from engine.utils import (
@@ -1015,10 +1016,24 @@ def create_react_agent(
                 and getattr(m, "status", None) != "error"
             ):
                 return END
+            # multi_step_service NÃO é return_direct (multi-uso), mas quando volta
+            # `interactive_sent` o MCP já enviou os botões ao cidadão out-of-band →
+            # o turno encerra aqui. Sem isso o LLM re-chama o workflow e/ou escreve
+            # texto, gerando confirmação duplicada (bug 2026-06-19).
+            if is_mss_interactive_sent_message(m):
+                return END
 
         # handle a case of parallel tool calls where
         # the tool w/ `return_direct` was executed in a different `Send`
         if isinstance(m, AIMessage) and m.tool_calls:
+            # LIMITAÇÃO CONHECIDA (parallel Send v2): se o LLM chamar
+            # multi_step_service JUNTO com outra tool no MESMO AIMessage, a branch da
+            # tool irmã roda este router sem o ToolMessage `interactive_sent` da MSS no
+            # seu estado (Send separado) → cai em entrypoint e re-invoca o agente. O
+            # check `is_mss_interactive_sent_message` acima cobre o caso SEQUENCIAL
+            # (padrão do confirm de endereço/identificação no POC, onde a MSS é chamada
+            # sozinha). Fechar o caso paralelo exigiria return_direct by-name +
+            # extração da `description` da MSS (TYPE B) — mudança maior, adiada.
             has_direct_tool_error = any(
                 message.name in should_return_direct
                 and getattr(message, "status", None) == "error"
@@ -1032,12 +1047,16 @@ def create_react_agent(
 
         return entrypoint
 
-    if should_return_direct:
-        workflow.add_conditional_edges(
-            "tools", route_tool_responses, path_map=[entrypoint, END]
-        )
-    else:
-        workflow.add_edge("tools", entrypoint)
+    # route_tool_responses é SEMPRE registrado: além das tools `return_direct`
+    # (should_return_direct), ele encerra o turno em retornos `interactive_sent` do
+    # multi_step_service (que NÃO está em should_return_direct). Sem isso, num tool-set
+    # SEM tools interativas, o interativo já enviado out-of-band seria seguido de
+    # re-chamada do LLM → confirmação duplicada (bug 2026-06-19). Com should_return_direct
+    # vazio, route_tool_responses só retorna `entrypoint` (idêntico ao edge incondicional
+    # anterior) OU END pelo check do MSS interactive_sent.
+    workflow.add_conditional_edges(
+        "tools", route_tool_responses, path_map=[entrypoint, END]
+    )
 
     # Finally, we compile it!
     # This compiles it into a LangChain Runnable,

--- a/engine/interactive_tools.py
+++ b/engine/interactive_tools.py
@@ -59,6 +59,47 @@ def is_failed_interactive_tool_message(message: object) -> bool:
     )
 
 
+def _tool_message_text(message: ToolMessage) -> str:
+    """Extrai o texto JSON do ``content`` de um ToolMessage de forma robusta:
+    aceita ``str``, lista de blocos ``[{'type':'text','text':...}]`` (formato do
+    adapter MCP) ou ``dict``."""
+    content = message.content
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list) and content:
+        first = content[0]
+        if isinstance(first, dict):
+            return str(first.get("text", "") or "")
+        return str(first)
+    if isinstance(content, dict):
+        return str(content.get("text", "") or "")
+    return str(content) if content is not None else ""
+
+
+def is_mss_interactive_sent_message(message: object) -> bool:
+    """Whether a ``multi_step_service`` ToolMessage signals an interactive já enviado
+    out-of-band (``status: interactive_sent``) — turno deve encerrar.
+
+    O ``multi_step_service`` NÃO está em ``ALL_INTERACTIVE_TOOL_NAMES`` (é multi-uso:
+    nem todo retorno é terminal), então não pode ser ``return_direct`` sempre. Mas
+    quando o gate ``ENABLE_INTERACTIVE_CONFIRM`` faz o MCP enviar os botões DIRETO pro
+    cidadão, o retorno traz ``status: interactive_sent`` + instrução "não escreva". Aí
+    o turno DEVE encerrar (a mensagem ao cidadão já saiu): sem isso o LLM re-chama o
+    workflow e/ou escreve texto, gerando confirmação duplicada (bug 2026-06-19)."""
+    if not isinstance(message, ToolMessage) or message.name != "multi_step_service":
+        return False
+    if getattr(message, "status", None) == "error":
+        return False
+    text = _tool_message_text(message)
+    if "interactive_sent" not in text:
+        return False
+    try:
+        data = json.loads(text)
+    except (ValueError, TypeError):
+        return False
+    return isinstance(data, dict) and data.get("status") == "interactive_sent"
+
+
 def put_recovery_ai_after_interactive_tool_error(messages: list) -> bool:
     """Prefer the model recovery text after a failed interactive tool call."""
     saw_failed_interactive = False

--- a/src/prompt_modules/media_inbound.py
+++ b/src/prompt_modules/media_inbound.py
@@ -94,14 +94,15 @@ Quando o cidadão compartilha localização pelo WhatsApp ("anexo → localizaç
    - **`validate_address(address=<texto>)`** somente se o JSON `media.address`/`media.name` já trouxer texto de endereço suficiente. Não passe latitude/longitude para `validate_address`.
    - **Outra tool explicitamente documentada como aceitando lat/lng**, se disponível.
    - Se nenhuma tool disponível aceitar coordenadas e não houver texto de endereço no JSON, explique que recebeu a localização, mas precisa confirmar o endereço em texto para continuar.
-3. **Apresente o endereço resolvido pro cidadão COM DISCLOSURE explícito da origem.** Não pergunte "Você se refere a Rua X?" — isso soa como se ele tivesse mencionado. Use formato:
+3. **Passe o endereço resolvido DIRETO pro workflow do serviço (`multi_step_service`) — NÃO confirme você mesmo.** Quando há um serviço ativo (luminária, poda, etc.), a confirmação do endereço é responsabilidade **ÚNICA do workflow**: ele apresenta o endereço resolvido e pede o "sim/não" ao cidadão (inclusive com botões). **NÃO** escreva "Está correto?", "Você se refere a Rua X?", nem liste o endereço pedindo confirmação — confirmar aqui **E** no workflow gera **dupla confirmação** (bug conhecido 2026-06-19). Apenas chame `multi_step_service` passando o endereço resolvido (logradouro/número/bairro) no payload; deixe o workflow confirmar.
 
-   > Pela localização que você compartilhou, identifiquei *Rua X, número Y - Bairro*. Está correto?
+4. **Só quando NÃO há serviço ativo** (o cidadão apenas compartilhou a localização, sem um pedido): aí sim apresente o endereço resolvido COM disclosure da origem e pergunte o que ele precisa — **sem** pedir confirmação do endereço. Formato:
 
-4. Aguarde confirmação. Se "sim", prossiga com esse endereço como dado confirmado no histórico do thread (importante: workflows downstream, especialmente `multi_step_service` pós-Flow, devem enriquecer payload com esse endereço — ver módulo `whatsapp_flow_inbound`).
-5. Se o cidadão corrigir ("não, é a Rua Z"), use a correção dele como endereço.
+   > Pela localização que você compartilhou, identifiquei *Rua X, número Y - Bairro*. Como posso te ajudar com esse endereço?
 
-**Nunca apresente endereço como fato consumado sem disclosure.** O cidadão precisa entender que VOCÊ resolveu a localização dele, não que ele te disse o endereço.
+5. Se o cidadão corrigir o endereço a qualquer momento ("não, é a Rua Z"), use a correção dele.
+
+**No caso sem-serviço-ativo (passo 4), nunca apresente o endereço como fato consumado sem disclosure** — o cidadão precisa entender que VOCÊ resolveu a localização dele, não que ele te disse o endereço.
 
 ### Caso especial: `media_type=unsupported` (geocoding via texto)
 

--- a/tests/unit/test_interactive_tools.py
+++ b/tests/unit/test_interactive_tools.py
@@ -5,7 +5,10 @@ from langchain_core.outputs import ChatGeneration, ChatResult
 
 from engine.custom_react_agent import create_react_agent
 from engine.agent import Agent
-from engine.interactive_tools import mark_interactive_tools_return_direct
+from engine.interactive_tools import (
+    mark_interactive_tools_return_direct,
+    is_mss_interactive_sent_message,
+)
 
 
 @tool
@@ -36,6 +39,46 @@ def send_whatsapp_list(body: str) -> list[dict[str, str]]:
 def list_service_options() -> list[dict[str, str]]:
     """Mock non-interactive tool returning a structured list."""
     return [{"name": "luminaria"}, {"name": "poda"}]
+
+
+def test_is_mss_interactive_sent_message_detects_interactive_sent():
+    """Bug 2026-06-19 (dupla confirmação): quando multi_step_service volta
+    `status: interactive_sent` (gate ENABLE_INTERACTIVE_CONFIRM enviou os botões
+    out-of-band), o turno deve encerrar. Aceita content str OU lista de blocos
+    `[{type:text,text}]` (formato do adapter MCP); ignora TYPE B (description),
+    outras tools, e retornos com erro."""
+    sent_str = ToolMessage(
+        content='{"status":"interactive_sent","next_step":"await_user_selection"}',
+        name="multi_step_service",
+        tool_call_id="a",
+    )
+    sent_list = ToolMessage(
+        content=[{"type": "text", "text": '{"status":"interactive_sent"}'}],
+        name="multi_step_service",
+        tool_call_id="b",
+    )
+    type_b = ToolMessage(
+        content='{"description":"Confirme o endereço","payload_schema":{}}',
+        name="multi_step_service",
+        tool_call_id="c",
+    )
+    other_tool = ToolMessage(
+        content='{"status":"interactive_sent"}',
+        name="google_search",
+        tool_call_id="d",
+    )
+    errored = ToolMessage(
+        content='{"status":"interactive_sent"}',
+        name="multi_step_service",
+        tool_call_id="e",
+        status="error",
+    )
+    assert is_mss_interactive_sent_message(sent_str) is True
+    assert is_mss_interactive_sent_message(sent_list) is True
+    assert is_mss_interactive_sent_message(type_b) is False
+    assert is_mss_interactive_sent_message(other_tool) is False
+    assert is_mss_interactive_sent_message(errored) is False
+    assert is_mss_interactive_sent_message(AIMessage(content="x")) is False
 
 
 def test_interactive_tools_return_direct_for_all_interactive_messages():


### PR DESCRIPTION
## O que (direção escolhida: workflow é a única fonte de confirmação)
Corrige a **dupla confirmação** (texto-gêmeo + botões) em passos interativos do POC (device-test 2026-06-19).

**Root cause:** (a) o engine/LLM confirmava o geocode E o workflow confirmava (dois caminhos); (b) `multi_step_service` não é `return_direct` → o LLM re-chamava/escrevia após o interativo já enviado out-of-band.

**Fix:**
- `media_inbound.py`: após o geocode, o engine **delega pro `multi_step_service` e NÃO confirma** (só apresenta+pergunta no caso sem-serviço-ativo). Supersede o #115 (disclosure), que era ineficaz.
- `interactive_tools.py`: `is_mss_interactive_sent_message` detecta `status:interactive_sent` (content str/list/dict) + teste.
- `custom_react_agent.py`: `route_tool_responses` encerra o turno em `interactive_sent` do MSS → o LLM não re-chama/escreve. Router **sempre registrado** (P2 codex #1).

## Limitação documentada (P2 codex #2)
**Parallel Send** (MSS + outra tool no mesmo AIMessage) não fecha no router v2 (a branch irmã não vê o resultado da MSS). Cobre o caso **sequencial** (padrão do POC, MSS chamada sozinha no confirm). Fechar o paralelo exige `return_direct` by-name + extração da `description` (mudança maior) — **adiado, validar via device-test**.

## Status
- 20 testes verdes (incl. detector). 
- Supersede engine #115 (segurado).
- Falta: /deploy + eval + device-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)