### PR TITLE
fix(engine): rede de segurança contra turno-vazio (no-response Flow-first)

### DIFF
--- a/engine/agent.py
+++ b/engine/agent.py
@@ -42,6 +42,7 @@ from engine.custom_react_agent import create_react_agent
 from engine.audio_mode import inject_audio_directive
 from engine.interactive_tools import (
     add_interactive_tool_preview_message,
+    ensure_non_empty_assistant_turn,
     put_interactive_tool_messages_last,
     put_recovery_ai_after_interactive_tool_error,
 )
@@ -1506,6 +1507,12 @@ class Agent(AsyncQueryable, AsyncStreamQueryable, Queryable, StreamQueryable):
         try:
             result = await self._graph.ainvoke(**kwargs)
             filtered_result = self._filter_current_interaction(result)
+            # Resultado FINAL (não streaming): garante que o turno nunca saia 100%
+            # vazio (no-response device-confirmado 2026-06-20). Só aqui — não em
+            # _filter_current_interaction, que é compartilhado com chunks de streaming
+            # (que podem ser estados intermediários só com o HumanMessage).
+            if isinstance(filtered_result, dict):
+                ensure_non_empty_assistant_turn(filtered_result.get("messages"))
 
             # Simple tracing
             self._trace_conversation(filtered_result, **kwargs)
@@ -1565,6 +1572,12 @@ class Agent(AsyncQueryable, AsyncStreamQueryable, Queryable, StreamQueryable):
         try:
             result = self._graph.invoke(**kwargs)
             filtered_result = self._filter_current_interaction(result)
+            # Resultado FINAL (não streaming): garante que o turno nunca saia 100%
+            # vazio (no-response device-confirmado 2026-06-20). Só aqui — não em
+            # _filter_current_interaction, que é compartilhado com chunks de streaming
+            # (que podem ser estados intermediários só com o HumanMessage).
+            if isinstance(filtered_result, dict):
+                ensure_non_empty_assistant_turn(filtered_result.get("messages"))
 
             # Simple tracing
             self._trace_conversation(filtered_result, **kwargs)

--- a/engine/interactive_tools.py
+++ b/engine/interactive_tools.py
@@ -100,6 +100,114 @@ def is_mss_interactive_sent_message(message: object) -> bool:
     return isinstance(data, dict) and data.get("status") == "interactive_sent"
 
 
+# Tools cujo RETORNO já É a mensagem voltada ao cidadão e o Mule vira ``agentMedia``
+# (webhook-flow.xml: canonicalToolReturn {send_whatsapp_media, build_whatsapp_flow_envelope,
+# send_whatsapp_buttons, send_whatsapp_list} + audioTR generate_audio_response). As
+# interativas Flow/botões/lista já estão em ALL_INTERACTIVE_TOOL_NAMES; aqui ficam as
+# de mídia pura. Usado pelo guard de turno-vazio pra NÃO injetar fallback quando a
+# saída ao cidadão já saiu por uma dessas (evitaria duplicar/descartar).
+MEDIA_RETURN_TOOL_NAMES = frozenset({"send_whatsapp_media", "generate_audio_response"})
+
+
+def _media_tool_succeeded(message: ToolMessage) -> bool:
+    """Mídia realmente disponível? Tools de mídia podem retornar falha a nível de DADO
+    (``{"status":"error"/"deferred"/"failed"}``) num ToolMessage normal — aí não há
+    mídia pro cidadão e o fallback NÃO deve ser suprimido."""
+    text = _tool_message_text(message)
+    try:
+        data = json.loads(text)
+    except (ValueError, TypeError):
+        return True  # não-JSON: conservador (assume saída; não injeta por cima de mídia)
+    if isinstance(data, dict):
+        return str(data.get("status", "")).lower() not in ("error", "deferred", "failed")
+    return True
+
+
+def _is_citizen_facing_tool_message(message: object) -> bool:
+    """ToolMessage cujo retorno é a mensagem ao cidadão: interativo (Flow/botões/lista
+    via return_direct), ``interactive_sent`` out-of-band, ou mídia (áudio/imagem/…)
+    de SUCESSO. Tools INTERNAS (google_search, validate_address, multi_step_service
+    não-terminal) NÃO contam — após elas, um turno vazio AINDA é no-response e merece
+    o fallback."""
+    if is_successful_interactive_tool_message(message):
+        return True
+    if is_mss_interactive_sent_message(message):
+        return True
+    return (
+        isinstance(message, ToolMessage)
+        and getattr(message, "status", None) != "error"
+        and message.name in MEDIA_RETURN_TOOL_NAMES
+        and _media_tool_succeeded(message)
+    )
+
+
+# Fallback p/ turno bem-sucedido mas SEM nada voltado ao cidadão (ver
+# ensure_non_empty_assistant_turn). Genérico de propósito: o turno-vazio pode
+# ocorrer em qualquer contexto, não só luminária.
+EMPTY_TURN_FALLBACK_MESSAGE = (
+    "Desculpe, não consegui entender sua última mensagem. 😕 "
+    "Pode reformular ou me dizer de outro jeito o que você precisa?"
+)
+
+
+def _ai_message_has_visible_text(message: object) -> bool:
+    """AIMessage com TEXTO final voltado ao cidadão: SEM tool_calls (preâmbulo de tool
+    não é resposta final) e com texto de verdade (str não-vazia ou bloco ``type:text``
+    — exclui blocos de thinking quando include_thoughts=True)."""
+    if not isinstance(message, AIMessage) or getattr(message, "tool_calls", None):
+        return False
+    content = message.content
+    if isinstance(content, str):
+        return bool(content.strip())
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, str) and block.strip():
+                return True
+            if (
+                isinstance(block, dict)
+                and block.get("type", "text") == "text"
+                and str(block.get("text", "")).strip()
+            ):
+                return True
+    return False
+
+
+def ensure_non_empty_assistant_turn(messages: list) -> bool:
+    """Garante que um turno bem-sucedido NUNCA termine sem nada pro cidadão.
+
+    Bug confirmado (device-test 2026-06-20): com um Flow card pendente, o LLM às
+    vezes emite um AIMessage VAZIO (sem content, sem tool_calls) e o grafo encerra o
+    turno — o Mule então pula o envio (``outbound_skipped_empty`` /
+    ``completed_no_assistant_message``) e o cidadão fica sem resposta. A rede de
+    segurança do #89 só cobre EXCEÇÃO; sucesso-vazio passava batido.
+
+    Injeta um fallback SOMENTE quando o turno não produziu NADA voltado ao cidadão:
+    nenhum texto de assistente E nenhuma tool VOLTADA AO CIDADÃO (interativo via
+    return_direct, ``interactive_sent`` out-of-band, ou mídia). Tools internas
+    (busca, geocode, multi_step_service não-terminal) NÃO contam — um turno vazio
+    depois delas ainda é no-response. NÃO injeta quando há saída ao cidadão (evita
+    duplicar/descartar). Espelha o discriminador de skip do Mule (sem texto + sem
+    interactive + sem mídia). Roda só no RESULTADO FINAL de ``Agent.query`` /
+    ``async_query`` (NÃO em chunks de streaming, que podem ser estados intermediários
+    só com o HumanMessage), na cópia já filtrada (não polui o checkpoint).
+
+    Retorna True se injetou o fallback.
+    """
+    if not isinstance(messages, list):
+        return False
+    if any(_ai_message_has_visible_text(message) for message in messages):
+        return False  # já há texto final pro cidadão (não conta preâmbulo de tool/thinking)
+    if any(_is_citizen_facing_tool_message(message) for message in messages):
+        return False  # interativo / mídia / out-of-band já é a saída ao cidadão
+    messages.append(
+        AIMessage(
+            content=EMPTY_TURN_FALLBACK_MESSAGE,
+            additional_kwargs={"synthetic_empty_turn_fallback": True},
+        )
+    )
+    return True
+
+
 def put_recovery_ai_after_interactive_tool_error(messages: list) -> bool:
     """Prefer the model recovery text after a failed interactive tool call."""
     saw_failed_interactive = False

--- a/tests/unit/test_empty_turn_fallback.py
+++ b/tests/unit/test_empty_turn_fallback.py
@@ -1,0 +1,118 @@
+"""Testes do safety-net contra turno-vazio (no-response device-confirmado 2026-06-20).
+
+Com um Flow card pendente, o LLM às vezes emite um AIMessage VAZIO (sem content, sem
+tool_calls); o grafo encerra o turno e o Mule pula o envio
+(``outbound_skipped_empty`` / ``completed_no_assistant_message``) → cidadão sem
+resposta. ``ensure_non_empty_assistant_turn`` injeta um fallback SOMENTE quando o turno
+não produziu nada voltado ao cidadão (sem texto E sem tool voltada ao cidadão), sem
+duplicar interativo/mídia. Tools INTERNAS não contam (um vazio depois delas ainda é
+no-response).
+"""
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from engine.interactive_tools import (
+    ensure_non_empty_assistant_turn,
+    EMPTY_TURN_FALLBACK_MESSAGE,
+)
+
+
+def test_injects_on_empty_turn():
+    """Turno bug: HumanMessage + AIMessage vazio, sem tool → injeta o fallback."""
+    messages = [HumanMessage(content="quero abrir um chamado"), AIMessage(content="")]
+    injected = ensure_non_empty_assistant_turn(messages)
+    assert injected is True
+    assert messages[-1].content == EMPTY_TURN_FALLBACK_MESSAGE
+    assert messages[-1].additional_kwargs.get("synthetic_empty_turn_fallback") is True
+
+
+def test_injects_after_internal_tool():
+    """Tool INTERNA (google_search) + turno vazio → ainda é no-response → injeta.
+
+    Regressão do P2 codex: o check largo "qualquer ToolMessage → pula" deixava o
+    cidadão sem resposta em turnos com tool interna + AIMessage vazio."""
+    messages = [
+        HumanMessage(content="qual o horário?"),
+        ToolMessage(content="resultado", name="google_search", tool_call_id="t0"),
+        AIMessage(content=""),
+    ]
+    assert ensure_non_empty_assistant_turn(messages) is True
+    assert messages[-1].content == EMPTY_TURN_FALLBACK_MESSAGE
+
+
+def test_noop_when_text_present():
+    """Já há texto pro cidadão → não injeta."""
+    messages = [HumanMessage(content="oi"), AIMessage(content="Olá! 😊")]
+    assert ensure_non_empty_assistant_turn(messages) is False
+    assert len(messages) == 2
+
+
+def test_noop_when_interactive_sent_out_of_band():
+    """Interativo já enviado out-of-band (ToolMessage) → não injeta (não duplica)."""
+    messages = [
+        HumanMessage(content="luminária"),
+        ToolMessage(
+            content='{"status": "interactive_sent"}',
+            name="multi_step_service",
+            tool_call_id="t1",
+        ),
+        AIMessage(content=""),
+    ]
+    assert ensure_non_empty_assistant_turn(messages) is False
+    assert all(
+        m.additional_kwargs.get("synthetic_empty_turn_fallback") is not True
+        for m in messages
+        if isinstance(m, AIMessage)
+    )
+
+
+def test_noop_when_media_tool_ran():
+    """Tool de MÍDIA (generate_audio_response, vira agentMedia no Mule) → não injeta."""
+    messages = [
+        HumanMessage(content="manda o áudio"),
+        ToolMessage(content="ok", name="generate_audio_response", tool_call_id="t2"),
+        AIMessage(content=""),
+    ]
+    assert ensure_non_empty_assistant_turn(messages) is False
+    assert len(messages) == 3
+
+
+def test_noop_on_non_list():
+    """Robustez: filtered_result sem messages (None) → não estoura, não injeta."""
+    assert ensure_non_empty_assistant_turn(None) is False
+
+
+def test_injects_when_only_tool_call_preamble_then_empty():
+    """AIMessage com preâmbulo + tool_calls NÃO é resposta final; vazio depois → injeta.
+
+    Regressão do P2 codex round 2: content de um AIMessage que também tem tool_calls
+    (preâmbulo/thinking) não pode contar como resposta final entregue."""
+    messages = [
+        HumanMessage(content="qual o horário?"),
+        AIMessage(
+            content="Deixa eu verificar...",
+            tool_calls=[{"name": "google_search", "args": {}, "id": "tc1"}],
+        ),
+        ToolMessage(content="resultado", name="google_search", tool_call_id="tc1"),
+        AIMessage(content=""),
+    ]
+    assert ensure_non_empty_assistant_turn(messages) is True
+    assert messages[-1].content == EMPTY_TURN_FALLBACK_MESSAGE
+
+
+def test_injects_when_media_tool_deferred():
+    """Mídia com falha a nível de dado ({status:deferred}) → sem mídia → injeta.
+
+    Regressão do P2 codex round 2: tool de mídia pode retornar falha de dado num
+    ToolMessage normal; aí não há mídia e o fallback NÃO pode ser suprimido."""
+    messages = [
+        HumanMessage(content="manda o áudio"),
+        ToolMessage(
+            content='{"status": "deferred"}',
+            name="generate_audio_response",
+            tool_call_id="t3",
+        ),
+        AIMessage(content=""),
+    ]
+    assert ensure_non_empty_assistant_turn(messages) is True
+    assert messages[-1].content == EMPTY_TURN_FALLBACK_MESSAGE


### PR DESCRIPTION
## No-response (rastreado E2E)
Device-test 2026-06-20 (logs Mule+gateway): com um Flow card pendente, o LLM às vezes emite um **AIMessage VAZIO** (sem content, sem tool_calls) → grafo encerra o turno → Mule pula o envio (`outbound_skipped_empty`/`completed_no_assistant_message`) → **cidadão sem resposta**. A rede de segurança do #89 só cobria **exceção**; sucesso-vazio passava batido. Gateway+Mule estavam certos — era comportamento do engine (Flow-first).

## Fix
`ensure_non_empty_assistant_turn` injeta um fallback **só quando o turno não produziu nada voltado ao cidadão**:
- sem **texto final** (exclui preâmbulo de tool / blocos de thinking);
- sem **tool voltada ao cidadão**: interativo (return_direct), `interactive_sent` out-of-band, ou **mídia de sucesso** (espelha o `canonicalToolReturn` do Mule; mídia com `status:deferred/error` não conta);
- tools **internas** (busca/geocode) NÃO contam → vazio depois delas ainda injeta.

Roda **só no resultado final** de `query`/`async_query` (não em chunks de streaming = estados intermediários). **Neutro a serviço** (output assembly, não triagem) — respeita a lição do #105.

## Validação
27 testes (6 novos), **codex limpo (3 iterações)**. ⚠️ **Precisa de eval-gate no deploy** (mudança de comportamento do engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)