### PR TITLE
feat(prompt): modulo document_inbound (recebimento de PDF/TXT/CSV)

### DIFF
--- a/src/prompt_modules/__init__.py
+++ b/src/prompt_modules/__init__.py
@@ -35,6 +35,7 @@ from loguru import logger
 from src.prompt_modules import (
     audio_inbound,
     audio_response,
+    document_inbound,
     emoji_input,
     govbr_auth_gating,
     interactive_general,
@@ -163,6 +164,7 @@ ENABLED_MODULES = [
     vision_inbound,
     audio_inbound,
     video_inbound,
+    document_inbound,
     whatsapp_flow_inbound,
 ]
 if _audio_response_enabled:

--- a/src/prompt_modules/document_inbound.py
+++ b/src/prompt_modules/document_inbound.py
@@ -1,0 +1,78 @@
+"""
+Módulo de prompt: instruções para o LLM chamar a tool MCP
+``analyze_inbound_document`` (Gemini — PDF/TXT/CSV) depois de
+``register_inbound_media`` quando o cidadão envia um documento pelo WhatsApp.
+
+Estrutura espelha ``vision_inbound`` / ``video_inbound`` via
+``AnalyzableMediaSpec`` (ADR-018). Este arquivo fica só com o que é
+document-specific: como usar o conteúdo extraído no atendimento.
+
+A UM anexa o documento como ``ContentVersion`` (validado ao vivo 2026-07-02:
+FileType=PDF). O download + leitura acontecem no MCP; aqui só ensinamos o LLM
+a chamar a tool e aproveitar o texto extraído sem pedir o cidadão redigitar.
+"""
+
+from src.prompt_modules._analyzable_media_template import (
+    AnalyzableMediaSpec,
+    render_module_prompt,
+)
+
+MODULE_NAME = "document_inbound"
+
+
+_DOCUMENT_GUIDANCE = """\
+### Retorno de `analyze_inbound_document`
+
+O `analysis` retornado tem o schema:
+
+```
+{
+  "conteudo_extraido": "<texto que o Gemini leu do documento: resumo do pedido, endereco, dados relevantes>"
+}
+```
+
+### Como usar o conteúdo extraído
+
+- Trate `analysis.conteudo_extraido` como **mensagem real do cidadão** — o que
+  ele mandou no documento equivale ao que teria digitado. **NÃO** peça pra
+  repetir em texto o que já está no arquivo.
+- **Continue o atendimento normalmente** com base no conteúdo extraído,
+  exatamente como faria se o cidadão tivesse digitado o mesmo texto. As regras
+  de serviço, triagem de escopo e workflows são as dos demais módulos deste
+  prompt — este módulo só garante que o conteúdo do documento **entre** no
+  atendimento; não redefine fluxo de serviço.
+- Se a tool retornar `status` diferente de `analyzed` (ex.: `deferred`,
+  `rejected`) ou `conteudo_extraido` vazio, use o `suggested_reply_pt_br` como
+  base e peça a informação em texto.
+
+### Exemplo de uso
+
+Cidadão anexa um PDF. `analyze_inbound_document` retorna
+`analysis.conteudo_extraido = "..."` com o texto lido. Próximo passo do LLM:
+usar esse texto como a mensagem do cidadão e seguir o atendimento normal (sem
+pedir pra redigitar), confirmando brevemente que leu o documento.
+"""
+
+
+_SPEC = AnalyzableMediaSpec(
+    module_name=MODULE_NAME,
+    media_type="document",
+    analyze_tool="analyze_inbound_document",
+    domain_noun_singular="documento",
+    domain_noun_indefinite="um documento",
+    domain_action="ler",
+    domain_action_present="leitura",
+    accepted_extensions=("pdf", "txt", "csv", "rtf"),
+    rejected_extensions_note=(
+        "doc/docx/xls/xlsx/ppt/pptx são binários que o Gemini não lê direto — "
+        "caem em fallback 'envie como PDF'."
+    ),
+    bytes_base64_arg_name="document_bytes_base64",
+    local_path_arg_name="local_document_path",
+    enable_env_var="ENABLE_DOCUMENT_ADDENDUM",
+    skip_analyze_on_real_user_text=False,  # caption não substitui a leitura do arquivo
+    type_specific_guidance=_DOCUMENT_GUIDANCE,
+)
+
+
+MODULE_PROMPT = render_module_prompt(_SPEC)

--- a/src/prompt_modules/media_inbound.py
+++ b/src/prompt_modules/media_inbound.py
@@ -46,7 +46,7 @@ Quando a entrada do cidadão começar com `[INBOUND_MEDIA]`, **NÃO** trate como
    [INBOUND_MEDIA] type=<media_type> user_number=<phone> media=<json> | user_text=<placeholder>
    ```
 
-   - `media_type` ∈ `{image, audio, video, location, unsupported, unknown}`
+   - `media_type` ∈ `{image, audio, video, document, location, unsupported, unknown}`
    - `user_number`: E.164 sem `+` (ex: `5521989091014`)
    - `media`: objeto JSON com metadados (pode ser `null` para `unsupported`/`unknown`)
    - `user_text`: conteúdo textual associado à mídia. **Atenção:** pode ser **placeholder gerado upstream** (quando nada de texto real veio do cidadão) ou **conteúdo real** (caption de imagem, transcrição de áudio, etc.).
@@ -78,6 +78,7 @@ Quando a entrada do cidadão começar com `[INBOUND_MEDIA]`, **NÃO** trate como
    - **Imagem:** chame `analyze_inbound_image` em seguida, quando disponível (conforme módulo `vision_inbound` deste prompt).
    - **Áudio:** chame `analyze_inbound_audio` em seguida, quando disponível (conforme módulo `audio_inbound` deste prompt) — a tool transcreve a fala e retorna intenção + workflow sugerido.
    - **Vídeo:** chame `analyze_inbound_video` em seguida, quando disponível (conforme módulo `video_inbound` deste prompt) — a tool analisa frames + áudio do vídeo e retorna descrição + transcrição + workflow sugerido.
+   - **Documento:** chame `analyze_inbound_document` em seguida, quando disponível (conforme módulo `document_inbound` deste prompt) — a tool lê PDF/TXT/CSV e retorna o conteúdo extraído (resumo do pedido, endereço, dados); use esse conteúdo como mensagem real do cidadão.
    - **Localização (`media_type=location`):** quando o cidadão compartilha pin do WhatsApp, o JSON `media` traz `latitude` e `longitude`. **NÃO peça endereço em texto** — chame uma tool que aceite coordenadas, como `reverse_geocode_address(latitude, longitude)`, quando ela estiver disponível. Detalhes no caso especial de `media_type=location` mais abaixo.
 
    Quando o módulo correspondente (`vision_inbound`/`audio_inbound`/`video_inbound`) estiver presente neste prompt e a tool estiver listada, use-os. Quando o módulo NÃO estiver presente OU a tool NÃO estiver listada, mantenha o fallback genérico do `register_inbound_media` (mensagem amigável pedindo texto).


### PR DESCRIPTION
Adiciona o modulo de prompt **document_inbound**: ensina o LLM a chamar `analyze_inbound_document` para `[INBOUND_MEDIA] type=document` e usar o conteudo extraido como mensagem do cidadao. `media_inbound` atualizado. Modulo enxuto (nao redefine fluxo). Revisado por codex.

Parte do rollout **document inbound** (SF deployada + gateway PR #57 + MCP PR #125).

🤖 Generated with [Claude Code](https://claude.com/claude-code)